### PR TITLE
Move broccoli-funnel to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,11 @@
   "homepage": "https://github.com/bustlelabs/mobiledoc-dom-renderer",
   "devDependencies": {
     "broccoli": "^0.16.3",
+    "broccoli-funnel": "^0.2.8",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-multi-builder": "^0.2.6",
     "broccoli-test-builder": "^0.2.0",
     "testem": "^0.9.0-1"
-  },
-  "dependencies": {
-    "broccoli-funnel": "^0.2.8"
   },
   "main": "dist/commonjs/mobiledoc-dom-renderer/index.js",
   "ember-addon": {


### PR DESCRIPTION
It appears like this won't need dependencies since the package is pre-built upon publishing
