### PR TITLE
update renderer to accept options

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -86,7 +86,8 @@ function renderCardSection([type, name, payload], renderState) {
     payload = {};
   }
   let element = createElement('div');
-  card.display.setup(element, {}, {name}, payload);
+  let cardOptions = renderState.options.cardOptions || {};
+  card.display.setup(element, cardOptions, {name}, payload);
   return element;
 }
 
@@ -127,11 +128,11 @@ export default class Renderer {
    *        properties
    * @return DOMNode
    */
-  render({version, sections: sectionData}, root=createElement('div'), cards={}) {
+  render({version, sections: sectionData}, root=createElement('div'), cards={}, options={}) {
     validateVersion(version);
     const [markerTypes, sections] = sectionData;
     cards.image = cards.image || ImageCard;
-    const renderState = {root, markerTypes, cards};
+    const renderState = {root, markerTypes, cards, options};
 
     if (Array.isArray(cards)) {
       throw new Error('`cards` must be passed as an object, not an array.');

--- a/tests/unit/renderer-test.js
+++ b/tests/unit/renderer-test.js
@@ -143,16 +143,21 @@ test('renders a mobiledoc with image section', (assert) => {
 });
 
 test('renders a mobiledoc with card section', (assert) => {
-  assert.expect(3);
+  assert.expect(4);
   let cardName = 'title-card';
   let payload = {
     name: 'bob'
   };
+  let options = {
+    cardOptions: {foo: 'bar'}
+  };
+  let expectedOptions = options.cardOptions;
   let TitleCard = {
     name: cardName,
     display: {
       setup(element, options, env, setupPayload) {
         assert.deepEqual(payload, setupPayload);
+        assert.deepEqual(options, expectedOptions);
         element.innerHTML = setupPayload.name;
       }
     }
@@ -166,9 +171,11 @@ test('renders a mobiledoc with card section', (assert) => {
       ]
     ]
   };
-  let rendered = renderer.render(mobiledoc, document.createElement('div'), {
+  let cards = {
     [cardName]: TitleCard
-  });
+  };
+  let element = document.createElement('div');
+  let rendered = renderer.render(mobiledoc, element, cards, options);
   assert.equal(rendered.childNodes.length, 1,
                'renders 1 section');
   let sectionEl = rendered.childNodes[0];


### PR DESCRIPTION
Passing options through allows consumers to define their own hooks (as is done in [`ember-mobildoc-editor`](https://github.com/bustlelabs/ember-mobiledoc-editor/blob/30fac3ed6edc791e2f6071b32fba89191dac9161/addon/components/mobiledoc-editor/component.js#L161), e.g.) to be able to integrate with other rendering systems.