### PR TITLE
Add sectionElementRenderer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,38 @@ document.getElementById('output').appendChild(result);
 
 The Renderer constructor accepts a single object with the following optional properties:
   * `cards` [array] - The list of card objects that the renderer may encounter in the mobiledoc
-  * `cardOptions` [object] - Options to pass to cards when they are rendered
+  * `atoms` [array] - The list of atom objects that the renderer may encounter in the mobiledoc
+  * `cardOptions` [object] - Options to pass to cards and atoms when they are rendered
   * `unknownCardHandler` [function] - Will be called when any unknown card is enountered
+  * `unknownAtomHandler` [function] - Will be called when any unknown atom is enountered
+  * `sectionElementRenderer` [object] - A map of hooks for section element rendering.
+    * Valid keys are P, H1, H2, H3, BLOCKQUOTE, PULL-QUOTE
+    * A valid value is a function that returns an element
 
 The return value from `renderer.render(mobiledoc)` is an object with two properties:
   * `result` [DOM Node] - The rendered result
   * `teardown` [function] - When called, this function will tear down the rendered mobiledoc and call any teardown handlers that were registered by cards when they were rendered
+
+#### sectionElementRenderer
+
+Use this renderer option to customize what element is used when rendering
+a section.
+
+```
+var renderer = new MobiledocDOMRenderer({
+  sectionElementRenderer: {
+    P: function() { return document.createElement('span'); },
+    H1: function() { return document.createElement('h2'); },
+    H2: function() {
+      var element = document.createElement('h2');
+      element.setAttribute('class', 'subheadline');
+      return element;
+    }
+    /* Valid keys are P, H1, H2, H3, BLOCKQUOTE, PULL-QUOTE */
+  }
+});
+var rendered = renderer.render(mobiledoc);
+```
 
 ### Tests
 

--- a/lib/renderer-factory.js
+++ b/lib/renderer-factory.js
@@ -41,14 +41,28 @@
  }
 
  export default class RendererFactory {
-   constructor({cards, atoms, cardOptions, unknownCardHandler, unknownAtomHandler}={}) {
+   constructor({
+     cards,
+     atoms,
+     cardOptions,
+     unknownCardHandler,
+     unknownAtomHandler,
+     sectionElementRenderer
+   }={}) {
      cards = cards || [];
      validateCards(cards);
      atoms = atoms || [];
      validateAtoms(atoms);
      cardOptions = cardOptions || {};
 
-     this.state = {cards, atoms, cardOptions, unknownCardHandler, unknownAtomHandler};
+     this.state = {
+       cards,
+       atoms,
+       cardOptions,
+       unknownCardHandler,
+       unknownAtomHandler,
+       sectionElementRenderer
+     };
    }
 
    render(mobiledoc) {

--- a/lib/renderers/0-2.js
+++ b/lib/renderers/0-2.js
@@ -44,8 +44,16 @@ function validateVersion(version) {
 
 export default class Renderer {
   constructor(mobiledoc, state) {
-    let { cards, cardOptions, atoms, unknownCardHandler } = state;
-    let { version, sections: sectionData } = mobiledoc;
+    let {
+      cards,
+      cardOptions,
+      unknownCardHandler,
+      sectionElementRenderer
+    } = state;
+    let {
+      version,
+      sections: sectionData
+    } = mobiledoc;
     validateVersion(version);
 
     const [markerTypes, sections] = sectionData;
@@ -54,9 +62,17 @@ export default class Renderer {
     this.markerTypes        = markerTypes;
     this.sections           = sections;
     this.cards              = cards;
-    this.atoms              = atoms;
     this.cardOptions        = cardOptions;
     this.unknownCardHandler = unknownCardHandler || this._defaultUnknownCardHandler;
+
+    this.sectionElementRenderer = {};
+    if (sectionElementRenderer) {
+      for (let key in sectionElementRenderer) {
+        if (sectionElementRenderer.hasOwnProperty(key)) {
+          this.sectionElementRenderer[key.toLowerCase()] = sectionElementRenderer[key];
+        }
+      }
+    }
 
     this._teardownCallbacks  = [];
     this._renderedChildNodes = [];
@@ -231,7 +247,13 @@ export default class Renderer {
       return;
     }
 
-    const element = createElement(tagName);
+    let renderer = createElement;
+    let lowerCaseTagName = tagName.toLowerCase();
+    if (this.sectionElementRenderer[lowerCaseTagName]) {
+      renderer = this.sectionElementRenderer[lowerCaseTagName];
+    }
+
+    let element = renderer(tagName);
     this.renderMarkersOnElement(element, markers);
     return element;
   }

--- a/lib/renderers/0-3.js
+++ b/lib/renderers/0-3.js
@@ -50,8 +50,21 @@ function validateVersion(version) {
 export default class Renderer {
   constructor(mobiledoc, state) {
 
-    let { cards, cardOptions, atoms, unknownCardHandler, unknownAtomHandler } = state;
-    let { version, sections, atoms: atomTypes, cards: cardTypes, markups: markerTypes } = mobiledoc;
+    let {
+      cards,
+      cardOptions,
+      atoms,
+      unknownCardHandler,
+      unknownAtomHandler,
+      sectionElementRenderer
+    } = state;
+    let {
+      version,
+      sections,
+      atoms: atomTypes,
+      cards: cardTypes,
+      markups: markerTypes
+    } = mobiledoc;
     validateVersion(version);
 
     this.root               = createDocumentFragment();
@@ -64,6 +77,15 @@ export default class Renderer {
     this.cardOptions        = cardOptions;
     this.unknownCardHandler = unknownCardHandler || this._defaultUnknownCardHandler;
     this.unknownAtomHandler = unknownAtomHandler || this._defaultUnknownAtomHandler;
+
+    this.sectionElementRenderer = {};
+    if (sectionElementRenderer) {
+      for (let key in sectionElementRenderer) {
+        if (sectionElementRenderer.hasOwnProperty(key)) {
+          this.sectionElementRenderer[key.toLowerCase()] = sectionElementRenderer[key];
+        }
+      }
+    }
 
     this._teardownCallbacks  = [];
   }
@@ -332,7 +354,13 @@ export default class Renderer {
       return;
     }
 
-    const element = createElement(tagName);
+    let renderer = createElement;
+    let lowerCaseTagName = tagName.toLowerCase();
+    if (this.sectionElementRenderer[lowerCaseTagName]) {
+      renderer = this.sectionElementRenderer[lowerCaseTagName];
+    }
+
+    let element = renderer(tagName);
     this.renderMarkersOnElement(element, markers);
     return element;
   }

--- a/tests/unit/renderers/0-2-test.js
+++ b/tests/unit/renderers/0-2-test.js
@@ -310,6 +310,7 @@ test('card may render nothing', (assert) => {
 });
 
 test('rendering nested mobiledocs in cards', (assert) => {
+  let renderer;
   let cards = [{
     name: 'nested-card',
     type: 'dom',
@@ -341,7 +342,7 @@ test('rendering nested mobiledocs in cards', (assert) => {
     ]
   };
 
-  let renderer = new Renderer({cards});
+  renderer = new Renderer({cards});
   let { result: rendered } = renderer.render(mobiledoc);
   assert.equal(rendered.childNodes.length, 1, 'renders 1 section');
   let card = rendered.childNodes[0];
@@ -566,4 +567,42 @@ test('XSS: unexpected markup types are not rendered', (assert) => {
   let script = result.querySelector('script');
   assert.ok(!script, 'no script tags rendered');
   document.getElementById('qunit-fixture').appendChild(result);
+});
+
+test('renders a mobiledoc with sectionElementRenderer', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [], // markers
+      [   // sections
+      [MARKUP_SECTION_TYPE, 'P', [
+        [[], 0, 'hello world']]
+      ],
+      [MARKUP_SECTION_TYPE, 'p', [
+        [[], 0, 'hello world']]
+      ],
+      [MARKUP_SECTION_TYPE, 'h1', [
+        [[], 0, 'hello world']]
+      ]
+      ]
+    ]
+  };
+  renderer = new Renderer({
+    sectionElementRenderer: {
+      p: () => document.createElement('pre'),
+      H1: () => document.createElement('h2')
+    }
+  });
+  let renderResult = renderer.render(mobiledoc);
+  let { result: rendered } = renderResult;
+  assert.equal(rendered.childNodes.length, 3,
+               'renders three sections');
+  assert.equal(rendered.childNodes[0].tagName, 'PRE',
+               'renders a pre');
+  assert.equal(rendered.childNodes[0].textContent, 'hello world',
+               'renders the text');
+  assert.equal(rendered.childNodes[1].tagName, 'PRE',
+               'renders a pre');
+  assert.equal(rendered.childNodes[2].tagName, 'H2',
+               'renders an h2');
 });

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -321,6 +321,7 @@ test('card may render nothing', (assert) => {
 });
 
 test('rendering nested mobiledocs in cards', (assert) => {
+  let renderer;
   let cards = [{
     name: 'nested-card',
     type: 'dom',
@@ -354,7 +355,7 @@ test('rendering nested mobiledocs in cards', (assert) => {
     ]
   };
 
-  let renderer = new Renderer({cards});
+  renderer = new Renderer({cards});
   let { result: rendered } = renderer.render(mobiledoc);
   assert.equal(rendered.childNodes.length, 1, 'renders 1 section');
   let card = rendered.childNodes[0];
@@ -745,4 +746,42 @@ test('rendering unknown atom uses unknownAtomHandler', (assert) => {
   };
   renderer = new Renderer({atoms: [], unknownAtomHandler, cardOptions});
   renderer.render(mobiledoc);
+});
+
+test('renders a mobiledoc with sectionElementRenderer', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: [
+      [MARKUP_SECTION_TYPE, 'P', [
+        [MARKUP_MARKER_TYPE, [], 0, 'hello world']]
+      ],
+      [MARKUP_SECTION_TYPE, 'p', [
+        [MARKUP_MARKER_TYPE, [], 0, 'hello world']]
+      ],
+      [MARKUP_SECTION_TYPE, 'h1', [
+        [MARKUP_MARKER_TYPE, [], 0, 'hello world']]
+      ]
+    ]
+  };
+  renderer = new Renderer({
+    sectionElementRenderer: {
+      p: () => document.createElement('pre'),
+      H1: () => document.createElement('h2')
+    }
+  });
+  let renderResult = renderer.render(mobiledoc);
+  let { result: rendered } = renderResult;
+  assert.equal(rendered.childNodes.length, 3,
+               'renders three sections');
+  assert.equal(rendered.childNodes[0].tagName, 'PRE',
+               'renders a pre');
+  assert.equal(rendered.childNodes[0].textContent, 'hello world',
+               'renders the text');
+  assert.equal(rendered.childNodes[1].tagName, 'PRE',
+               'renders a pre');
+  assert.equal(rendered.childNodes[2].tagName, 'H2',
+               'renders an h2');
 });


### PR DESCRIPTION
When rendering a Mobiledoc, the client may want to change how sections are rendered into DOM. This introduces an API for passing rendering implementations for section DOM into the renderer:

```js
var renderer = new MobiledocDOMRenderer({
  sectionElementRenderer: {
    P: function() { return document.createElement('span'); },
    H1: function() { return document.createElement('h2'); },
    H2: function() {
      var element = document.createElement('h2');
      element.setAttribute('class', 'subheadline');
      return element;
    }
    /* Valid keys are P, H1, H2, H3, BLOCKQUOTE, PULL-QUOTE */
  }
});
var rendered = renderer.render(mobiledoc);
```

@gdub22 