### PR TITLE
Add dom option for renderer, SimpleDOM tests

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -2,14 +2,21 @@
 var multiBuilder = require('broccoli-multi-builder');
 var mergeTrees = require('broccoli-merge-trees');
 var testBuilder = require('broccoli-test-builder');
+var Funnel = require('broccoli-funnel');
 
 var options = {
   packageName: 'mobiledoc-dom-renderer'
 };
 
+var simpleDOMTree = new Funnel('node_modules/simple-dom/dist/', {
+  include: ['simple-dom.js'],
+  destDir: 'tests'
+});
+
 module.exports = mergeTrees([
   multiBuilder.build('amd', options),
   multiBuilder.build('global', options),
   multiBuilder.build('commonjs', options),
-  testBuilder.build()
+  testBuilder.build(),
+  simpleDOMTree
 ]);

--- a/lib/cards/image.js
+++ b/lib/cards/image.js
@@ -1,11 +1,10 @@
-import { createElement } from '../utils/dom';
 import RENDER_TYPE from '../utils/render-type';
 
 export default {
   name: 'image',
   type: RENDER_TYPE,
-  render({payload}) {
-    let img = createElement('img');
+  render({payload, env: {dom}}) {
+    let img = dom.createElement('img');
     img.src = payload.src;
     return img;
   }

--- a/lib/renderer-factory.js
+++ b/lib/renderer-factory.js
@@ -47,7 +47,8 @@
      cardOptions,
      unknownCardHandler,
      unknownAtomHandler,
-     sectionElementRenderer
+     sectionElementRenderer,
+     dom
    }={}) {
      cards = cards || [];
      validateCards(cards);
@@ -55,13 +56,21 @@
      validateAtoms(atoms);
      cardOptions = cardOptions || {};
 
-     this.state = {
+     if (!dom) {
+       if (!window) {
+         throw new Error('A `dom` option must be provided to the renderer when running without window.document');
+       }
+       dom = window.document;
+     }
+
+     this.options = {
        cards,
        atoms,
        cardOptions,
        unknownCardHandler,
        unknownAtomHandler,
-       sectionElementRenderer
+       sectionElementRenderer,
+       dom
      };
    }
 
@@ -71,9 +80,9 @@
        case MOBILEDOC_VERSION_0_2:
        case undefined:
        case null:
-         return new Renderer_0_2(mobiledoc, this.state).render();
+         return new Renderer_0_2(mobiledoc, this.options).render();
        case MOBILEDOC_VERSION_0_3:
-         return new Renderer_0_3(mobiledoc, this.state).render();
+         return new Renderer_0_3(mobiledoc, this.options).render();
        default:
          throw new Error(`Unexpected Mobiledoc version "${version}"`);
      }

--- a/lib/renderers/0-2.js
+++ b/lib/renderers/0-2.js
@@ -1,11 +1,4 @@
-import {
-  createElement,
-  appendChild,
-  removeChild,
-  createTextNode,
-  setAttribute,
-  createDocumentFragment
-} from '../utils/dom';
+import { createTextNode } from '../utils/dom';
 import ImageCard from '../cards/image';
 import RENDER_TYPE from '../utils/render-type';
 import {
@@ -24,14 +17,14 @@ export const MOBILEDOC_VERSION = '0.2.0';
 const IMAGE_SECTION_TAG_NAME = 'img';
 const CARD_ELEMENT_TAG_NAME = 'div';
 
-function createElementFromMarkerType([tagName, attributes]=['', []]){
-  let element = createElement(tagName);
+function createElementFromMarkerType(dom, [tagName, attributes]=['', []]){
+  let element = dom.createElement(tagName);
   attributes = attributes || [];
 
   for (let i=0,l=attributes.length; i<l; i=i+2) {
     let propName = attributes[i],
         propValue = attributes[i+1];
-    setAttribute(element, propName, propValue);
+    element.setAttribute(propName, propValue);
   }
   return element;
 }
@@ -43,13 +36,14 @@ function validateVersion(version) {
 }
 
 export default class Renderer {
-  constructor(mobiledoc, state) {
+  constructor(mobiledoc, options) {
     let {
       cards,
       cardOptions,
       unknownCardHandler,
-      sectionElementRenderer
-    } = state;
+      sectionElementRenderer,
+      dom
+    } = options;
     let {
       version,
       sections: sectionData
@@ -58,7 +52,8 @@ export default class Renderer {
 
     const [markerTypes, sections] = sectionData;
 
-    this.root               = createDocumentFragment();
+    this.dom                = dom;
+    this.root               = dom.createDocumentFragment();
     this.markerTypes        = markerTypes;
     this.sections           = sections;
     this.cards              = cards;
@@ -88,11 +83,16 @@ export default class Renderer {
     this.sections.forEach(section => {
       let rendered = this.renderSection(section);
       if (rendered) {
-        appendChild(this.root, rendered);
+        this.root.appendChild(rendered);
       }
     });
     // maintain a reference to child nodes so they can be cleaned up later by teardown
-    this._renderedChildNodes = Array.prototype.slice.call(this.root.childNodes);
+    this._renderedChildNodes = [];
+    let node = this.root.firstChild;
+    while (node) {
+      this._renderedChildNodes.push(node);
+      node = node.nextSibling;
+    }
     return { result: this.root, teardown: () => this.teardown() };
   }
 
@@ -103,7 +103,7 @@ export default class Renderer {
     for (let i=0; i < this._renderedChildNodes.length; i++) {
       let node = this._renderedChildNodes[i];
       if (node.parentNode) {
-        removeChild(node.parentNode, node);
+        node.parentNode.removeChild(node);
       }
     }
   }
@@ -136,8 +136,8 @@ export default class Renderer {
         let markerType = this.markerTypes[openTypes[j]];
         let [tagName] = markerType;
         if (isValidMarkerType(tagName)) {
-          let openedElement = createElementFromMarkerType(markerType);
-          appendChild(currentElement, openedElement);
+          let openedElement = createElementFromMarkerType(this.dom, markerType);
+          currentElement.appendChild(openedElement);
           elements.push(openedElement);
           currentElement = openedElement;
         } else {
@@ -145,7 +145,7 @@ export default class Renderer {
         }
       }
 
-      appendChild(currentElement, createTextNode(text));
+      currentElement.appendChild(createTextNode(this.dom, text));
 
       for (let j=0, m=closeCount; j<m; j++) {
         elements.pop();
@@ -155,7 +155,7 @@ export default class Renderer {
   }
 
   renderListItem(markers) {
-    const element = createElement('li');
+    const element = this.dom.createElement('li');
     this.renderMarkersOnElement(element, markers);
     return element;
   }
@@ -164,15 +164,15 @@ export default class Renderer {
     if (!isValidSectionTagName(tagName, LIST_SECTION_TYPE)) {
       return;
     }
-    const element = createElement(tagName);
+    const element = this.dom.createElement(tagName);
     listItems.forEach(li => {
-      appendChild(element, (this.renderListItem(li)));
+      element.appendChild(this.renderListItem(li));
     });
     return element;
   }
 
   renderImageSection([type, src]) {
-    let element = createElement(IMAGE_SECTION_TAG_NAME);
+    let element = this.dom.createElement(IMAGE_SECTION_TAG_NAME);
     element.src = src;
     return element;
   }
@@ -201,6 +201,7 @@ export default class Renderer {
     let env = {
       name: card.name,
       isInEditor: false,
+      dom: this.dom,
       onTeardown: (callback) => this._registerTeardownCallback(callback)
     };
 
@@ -223,13 +224,13 @@ export default class Renderer {
     this._validateCardRender(rendered, card.name);
 
     if (rendered) {
-      appendChild(cardWrapper, rendered);
+      cardWrapper.appendChild(rendered);
     }
     return cardWrapper;
   }
 
   _createCardElement() {
-    return createElement(CARD_ELEMENT_TAG_NAME);
+    return this.dom.createElement(CARD_ELEMENT_TAG_NAME);
   }
 
   _validateCardRender(rendered, cardName) {
@@ -247,13 +248,14 @@ export default class Renderer {
       return;
     }
 
-    let renderer = createElement;
+    let element;
     let lowerCaseTagName = tagName.toLowerCase();
     if (this.sectionElementRenderer[lowerCaseTagName]) {
-      renderer = this.sectionElementRenderer[lowerCaseTagName];
+      element = this.sectionElementRenderer[lowerCaseTagName](tagName);
+    } else {
+      element = this.dom.createElement(tagName);
     }
 
-    let element = renderer(tagName);
     this.renderMarkersOnElement(element, markers);
     return element;
   }

--- a/lib/renderers/0-3.js
+++ b/lib/renderers/0-3.js
@@ -1,11 +1,4 @@
-import {
-  createElement,
-  appendChild,
-  removeChild,
-  createTextNode,
-  setAttribute,
-  createDocumentFragment
-} from '../utils/dom';
+import { createTextNode } from '../utils/dom';
 import ImageCard from '../cards/image';
 import RENDER_TYPE from '../utils/render-type';
 import {
@@ -29,14 +22,14 @@ export const MOBILEDOC_VERSION = '0.3.0';
 const IMAGE_SECTION_TAG_NAME = 'img';
 const CARD_ELEMENT_TAG_NAME = 'div';
 
-function createElementFromMarkerType([tagName, attributes]=['', []]){
-  let element = createElement(tagName);
+function createElementFromMarkerType(dom, [tagName, attributes]=['', []]){
+  let element = dom.createElement(tagName);
   attributes = attributes || [];
 
   for (let i=0,l=attributes.length; i<l; i=i+2) {
     let propName = attributes[i],
         propValue = attributes[i+1];
-    setAttribute(element, propName, propValue);
+    element.setAttribute(propName, propValue);
   }
   return element;
 }
@@ -56,7 +49,8 @@ export default class Renderer {
       atoms,
       unknownCardHandler,
       unknownAtomHandler,
-      sectionElementRenderer
+      sectionElementRenderer,
+      dom
     } = state;
     let {
       version,
@@ -67,7 +61,8 @@ export default class Renderer {
     } = mobiledoc;
     validateVersion(version);
 
-    this.root               = createDocumentFragment();
+    this.dom                = dom;
+    this.root               = this.dom.createDocumentFragment();
     this.sections           = sections;
     this.atomTypes          = atomTypes;
     this.cardTypes          = cardTypes;
@@ -106,7 +101,7 @@ export default class Renderer {
     this.sections.forEach(section => {
       let rendered = this.renderSection(section);
       if (rendered) {
-        appendChild(this.root, rendered);
+        this.root.appendChild(rendered);
       }
     });
     // maintain a reference to child nodes so they can be cleaned up later by teardown
@@ -121,7 +116,7 @@ export default class Renderer {
     for (let i=0; i < this._renderedChildNodes.length; i++) {
       let node = this._renderedChildNodes[i];
       if (node.parentNode) {
-        removeChild(node.parentNode, node);
+        node.parentNode.removeChild(node);
       }
     }
   }
@@ -154,8 +149,8 @@ export default class Renderer {
         let markerType = this.markerTypes[openTypes[j]];
         let [tagName] = markerType;
         if (isValidMarkerType(tagName)) {
-          let openedElement = createElementFromMarkerType(markerType);
-          appendChild(currentElement, openedElement);
+          let openedElement = createElementFromMarkerType(this.dom, markerType);
+          currentElement.appendChild( openedElement);
           elements.push(openedElement);
           currentElement = openedElement;
         } else {
@@ -165,10 +160,10 @@ export default class Renderer {
 
       switch (type) {
         case MARKUP_MARKER_TYPE:
-          appendChild(currentElement, createTextNode(value));
+          currentElement.appendChild(createTextNode(this.dom, value));
           break;
         case ATOM_MARKER_TYPE:
-          appendChild(currentElement, this._renderAtom(value));
+          currentElement.appendChild(this._renderAtom(value));
           break;
         default:
           throw new Error(`Unknown markup type (${type})`);
@@ -182,7 +177,7 @@ export default class Renderer {
   }
 
   renderListItem(markers) {
-    const element = createElement('li');
+    const element = this.dom.createElement('li');
     this.renderMarkersOnElement(element, markers);
     return element;
   }
@@ -191,15 +186,15 @@ export default class Renderer {
     if (!isValidSectionTagName(tagName, LIST_SECTION_TYPE)) {
       return;
     }
-    const element = createElement(tagName);
+    const element = this.dom.createElement(tagName);
     listItems.forEach(li => {
-      appendChild(element, (this.renderListItem(li)));
+      element.appendChild(this.renderListItem(li));
     });
     return element;
   }
 
   renderImageSection([type, src]) {
-    let element = createElement(IMAGE_SECTION_TAG_NAME);
+    let element = this.dom.createElement(IMAGE_SECTION_TAG_NAME);
     element.src = src;
     return element;
   }
@@ -243,6 +238,7 @@ export default class Renderer {
     let env = {
       name: card.name,
       isInEditor: false,
+      dom: this.dom,
       onTeardown: (callback) => this._registerTeardownCallback(callback)
     };
 
@@ -265,13 +261,13 @@ export default class Renderer {
     this._validateCardRender(rendered, card.name);
 
     if (rendered) {
-      appendChild(cardWrapper, rendered);
+      cardWrapper.appendChild(rendered);
     }
     return cardWrapper;
   }
 
   _createCardElement() {
-    return createElement(CARD_ELEMENT_TAG_NAME);
+    return this.dom.createElement(CARD_ELEMENT_TAG_NAME);
   }
 
   _validateCardRender(rendered, cardName) {
@@ -346,7 +342,7 @@ export default class Renderer {
 
     this._validateAtomRender(rendered, atom.name);
 
-    return rendered || createTextNode('');
+    return rendered || createTextNode(this.dom, '');
   }
 
   renderMarkupSection([type, tagName, markers]) {
@@ -354,13 +350,14 @@ export default class Renderer {
       return;
     }
 
-    let renderer = createElement;
+    let element;
     let lowerCaseTagName = tagName.toLowerCase();
     if (this.sectionElementRenderer[lowerCaseTagName]) {
-      renderer = this.sectionElementRenderer[lowerCaseTagName];
+      element = this.sectionElementRenderer[lowerCaseTagName](tagName);
+    } else {
+      element = this.dom.createElement(tagName);
     }
 
-    let element = renderer(tagName);
     this.renderMarkersOnElement(element, markers);
     return element;
   }

--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -1,30 +1,10 @@
-export function createElement(tagName) {
-  return document.createElement(tagName);
-}
-
-export function appendChild(target, child) {
-  target.appendChild(child);
-}
-
-export function removeChild(target, child) {
-  target.removeChild(child);
-}
-
 function addHTMLSpaces(text) {
   let nbsp = '\u00A0';
   return text.replace(/  /g, ' ' + nbsp);
 }
 
-export function createTextNode(text) {
-  return document.createTextNode(addHTMLSpaces(text));
-}
-
-export function setAttribute(node, propName, value) {
-  node.setAttribute(propName, value);
-}
-
-export function createDocumentFragment() {
-  return document.createDocumentFragment();
+export function createTextNode(dom, text) {
+  return dom.createTextNode(addHTMLSpaces(text));
 }
 
 export function normalizeTagName(tagName) {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
   "homepage": "https://github.com/bustlelabs/mobiledoc-dom-renderer",
   "devDependencies": {
     "broccoli": "^0.16.3",
+    "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-multi-builder": "^0.2.6",
     "broccoli-test-builder": "^0.2.0",
     "conventional-changelog": "^0.5.1",
+    "simple-dom": "^0.2.7",
     "testem": "^0.9.0-1"
   },
   "main": "dist/commonjs/mobiledoc-dom-renderer/index.js"

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -1,0 +1,31 @@
+/* global SimpleDOM */
+
+export function childNodesLength(element) {
+  let length = 0;
+  let node = element.firstChild;
+  while (node) {
+    length++;
+    node = node.nextSibling;
+  }
+  return length;
+}
+
+export function outerHTML(node) {
+  if (node.outerHTML) {
+    return node.outerHTML;
+  } else {
+    let serializer = new SimpleDOM.HTMLSerializer([]);
+    return serializer.serialize(node);
+  }
+}
+
+export function innerHTML(parentNode) {
+  let content = [];
+  let node = parentNode.firstChild;
+  while (node) {
+    content.push(outerHTML(node));
+    node = node.nextSibling;
+  }
+  return content.join('');
+}
+

--- a/tests/index.html
+++ b/tests/index.html
@@ -15,9 +15,12 @@
   <script src="/testem.js"></script>
 
   @@LOADER_JS
+
   <script src="../amd/mobiledoc-dom-renderer.js"></script>
 
   @@AMD_TEST_JS
+  <script src="./simple-dom.js"></script>
+
   @@TEST_LOADER_JS
 </body>
 </html>

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -1,4 +1,4 @@
-/* global QUnit */
+/* global QUnit, SimpleDOM */
 
 import Renderer from 'mobiledoc-dom-renderer';
 import ImageCard from 'mobiledoc-dom-renderer/cards/image';
@@ -9,6 +9,11 @@ import {
   CARD_SECTION_TYPE,
   IMAGE_SECTION_TYPE
 } from 'mobiledoc-dom-renderer/utils/section-types';
+import {
+  innerHTML,
+  outerHTML,
+  childNodesLength
+} from '../../helpers/dom';
 
 const { test, module } = QUnit;
 const MOBILEDOC_VERSION = '0.3.0';
@@ -20,11 +25,10 @@ import {
 } from 'mobiledoc-dom-renderer/utils/marker-types';
 
 let renderer;
-module('Unit: Mobiledoc DOM Renderer - 0.3', {
-  beforeEach() {
-    renderer = new Renderer();
-  }
-});
+
+// Add tests that should run with both simple-dom and
+// the window.document in this function.
+function generateTests() {
 
 test('renders an empty mobiledoc', (assert) => {
   let mobiledoc = {
@@ -37,7 +41,7 @@ test('renders an empty mobiledoc', (assert) => {
   let { result: rendered } = renderer.render(mobiledoc);
 
   assert.ok(!!rendered, 'renders result');
-  assert.equal(rendered.childNodes.length, 0, 'has no sections');
+  assert.equal(childNodesLength(rendered), 0, 'has no sections');
 });
 
 test('renders a mobiledoc without markups', (assert) => {
@@ -54,11 +58,11 @@ test('renders a mobiledoc without markups', (assert) => {
   };
   let renderResult = renderer.render(mobiledoc);
   let { result: rendered } = renderResult;
-  assert.equal(rendered.childNodes.length, 1,
+  assert.equal(childNodesLength(rendered), 1,
                'renders 1 section');
-  assert.equal(rendered.childNodes[0].tagName, 'P',
+  assert.equal(rendered.firstChild.tagName, 'P',
                'renders a P');
-  assert.equal(rendered.childNodes[0].textContent, 'hello world',
+  assert.equal(rendered.firstChild.firstChild.nodeValue, 'hello world',
                'renders the text');
 });
 
@@ -77,11 +81,11 @@ test('renders a mobiledoc with simple (no attributes) markup', (assert) => {
     ]
   };
   let { result: rendered } = renderer.render(mobiledoc);
-  assert.equal(rendered.childNodes.length, 1,
+  assert.equal(childNodesLength(rendered), 1,
                'renders 1 section');
-  let sectionEl = rendered.childNodes[0];
+  let sectionEl = rendered.firstChild;
 
-  assert.equal(sectionEl.innerHTML, '<b>hello world</b>');
+  assert.equal(innerHTML(sectionEl), '<b>hello world</b>');
 });
 
 test('renders a mobiledoc with complex (has attributes) markup', (assert) => {
@@ -99,11 +103,11 @@ test('renders a mobiledoc with complex (has attributes) markup', (assert) => {
     ]
   };
   let { result: rendered } = renderer.render(mobiledoc);
-  assert.equal(rendered.childNodes.length, 1,
+  assert.equal(childNodesLength(rendered), 1,
                'renders 1 section');
-  let sectionEl = rendered.childNodes[0];
+  let sectionEl = rendered.firstChild;
 
-  assert.equal(sectionEl.innerHTML, '<a href="http://google.com">hello world</a>');
+  assert.equal(innerHTML(sectionEl), '<a href="http://google.com">hello world</a>');
 });
 
 test('renders a mobiledoc with multiple markups in a section', (assert) => {
@@ -125,11 +129,11 @@ test('renders a mobiledoc with multiple markups in a section', (assert) => {
     ]
   };
   let { result: rendered } = renderer.render(mobiledoc);
-  assert.equal(rendered.childNodes.length, 1,
+  assert.equal(childNodesLength(rendered), 1,
                'renders 1 section');
-  let sectionEl = rendered.childNodes[0];
+  let sectionEl = rendered.firstChild;
 
-  assert.equal(sectionEl.innerHTML, '<b>hello <i>brave new </i>world</b>');
+  assert.equal(innerHTML(sectionEl), '<b>hello <i>brave new </i>world</b>');
 });
 
 test('renders a mobiledoc with image section', (assert) => {
@@ -143,9 +147,9 @@ test('renders a mobiledoc with image section', (assert) => {
     ]
   };
   let { result: rendered } = renderer.render(mobiledoc);
-  assert.equal(rendered.childNodes.length, 1,
+  assert.equal(childNodesLength(rendered), 1,
                'renders 1 section');
-  let sectionEl = rendered.childNodes[0];
+  let sectionEl = rendered.firstChild;
 
   assert.equal(sectionEl.src, dataUri);
 });
@@ -166,9 +170,9 @@ test('renders a mobiledoc with built-in image card', (assert) => {
     ]
   };
   let { result: rendered } = renderer.render(mobiledoc);
-  assert.equal(rendered.childNodes.length, 1,
+  assert.equal(childNodesLength(rendered), 1,
                'renders 1 section');
-  let sectionEl = rendered.childNodes[0];
+  let sectionEl = rendered.firstChild;
 
   assert.equal(sectionEl.firstChild.tagName, 'IMG');
   assert.equal(sectionEl.firstChild.src, dataUri);
@@ -188,20 +192,20 @@ test('render mobiledoc with list section and list items', (assert) => {
     ]
   };
   let { result: rendered } = renderer.render(mobiledoc, document.createElement('div'));
-  assert.equal(rendered.childNodes.length, 1, 'renders 1 section');
+  assert.equal(childNodesLength(rendered), 1, 'renders 1 section');
 
-  const section = rendered.childNodes[0];
+  const section = rendered.firstChild;
   assert.equal(section.tagName, 'UL');
 
-  const items = section.childNodes;
-  assert.equal(items.length, 2, '2 list items');
+  assert.equal(childNodesLength(section), 2, '2 list items');
 
-  assert.equal(items[0].tagName, 'LI', 'correct tagName for item 1');
-  assert.equal(items[0].childNodes[0].textContent, 'first item',
+  const items = section.childNodes;
+  assert.equal(items.item(0).tagName, 'LI', 'correct tagName for item 1');
+  assert.equal(items.item(0).firstChild.nodeValue, 'first item',
                'correct text node for item 1');
 
-  assert.equal(items[1].tagName, 'LI', 'correct tagName for item 2');
-  assert.equal(items[1].childNodes[0].textContent, 'second item',
+  assert.equal(items.item(1).tagName, 'LI', 'correct tagName for item 2');
+  assert.equal(items.item(1).firstChild.nodeValue, 'second item',
                'correct text node for item 2');
 });
 
@@ -237,10 +241,10 @@ test('renders a mobiledoc with card section', (assert) => {
 
   renderer = new Renderer({cards: [TitleCard], cardOptions: expectedOptions});
   let { result: rendered } = renderer.render(mobiledoc);
-  assert.equal(rendered.childNodes.length, 1, 'renders 1 section');
-  let sectionEl = rendered.childNodes[0];
+  assert.equal(childNodesLength(rendered), 1, 'renders 1 section');
+  let sectionEl = rendered.firstChild;
 
-  assert.equal(sectionEl.innerHTML, expectedPayload.name);
+  assert.equal(innerHTML(sectionEl), expectedPayload.name);
 });
 
 test('throws when given invalid card type', (assert) => {
@@ -357,11 +361,11 @@ test('rendering nested mobiledocs in cards', (assert) => {
 
   renderer = new Renderer({cards});
   let { result: rendered } = renderer.render(mobiledoc);
-  assert.equal(rendered.childNodes.length, 1, 'renders 1 section');
-  let card = rendered.childNodes[0];
-  assert.equal(card.childNodes.length, 1, 'card has 1 child');
-  assert.equal(card.childNodes[0].tagName, 'P', 'card has P child');
-  assert.equal(card.childNodes[0].innerText, 'hello world');
+  assert.equal(childNodesLength(rendered), 1, 'renders 1 section');
+  let card = rendered.firstChild;
+  assert.equal(childNodesLength(card), 1, 'card has 1 child');
+  assert.equal(card.firstChild.tagName, 'P', 'card has P child');
+  assert.equal(card.firstChild.innerText, 'hello world');
 });
 
 test('rendering unknown card without unknownCardHandler throws', (assert) => {
@@ -425,66 +429,6 @@ test('throws if given an object of cards', (assert) => {
   );
 });
 
-test('teardown removes rendered sections from dom', (assert) => {
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    atoms: [],
-    cards: [],
-    markups: [],
-    sections: [
-      [MARKUP_SECTION_TYPE, 'p', [
-        [MARKUP_MARKER_TYPE, [], 0, 'Hello world']
-      ]]
-    ]
-  };
-
-  let { result: rendered, teardown } = renderer.render(mobiledoc);
-  assert.equal(rendered.childNodes.length, 1, 'renders 1 section');
-
-  let fixture = document.getElementById('qunit-fixture');
-  fixture.appendChild(rendered);
-
-  assert.ok(fixture.childNodes.length === 1, 'precond - result is appended');
-
-  teardown();
-
-  assert.ok(fixture.childNodes.length === 0, 'rendered result removed after teardown');
-});
-
-test('teardown hook calls registered teardown methods', (assert) => {
-  let cardName = 'title-card';
-  let didTeardown = false;
-
-  let card = {
-    name: cardName,
-    type: 'dom',
-    render({env}) {
-      env.onTeardown(() => didTeardown = true);
-    }
-  };
-
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    atoms: [],
-    cards: [
-      [cardName]
-    ],
-    markups: [],
-    sections: [
-      [CARD_SECTION_TYPE, 0]
-    ]
-  };
-
-  renderer = new Renderer({cards: [card]});
-  let { teardown } = renderer.render(mobiledoc);
-
-  assert.ok(!didTeardown, 'teardown not called');
-
-  teardown();
-
-  assert.ok(didTeardown, 'teardown called');
-});
-
 test('multiple spaces should preserve whitespace with nbsps', (assert) => {
   let space = ' ';
   let repeat = (str, count) => {
@@ -520,7 +464,7 @@ test('multiple spaces should preserve whitespace with nbsps', (assert) => {
   ].join('');
   let { result: rendered } = renderer.render(mobiledoc);
   let textNode = rendered.firstChild.firstChild;
-  assert.equal(textNode.textContent, expectedText, 'renders the text');
+  assert.equal(textNode.nodeValue, expectedText, 'renders the text');
 });
 
 test('throws when given unexpected mobiledoc version', (assert) => {
@@ -560,9 +504,8 @@ test('XSS: unexpected markup and list section tag names are not renderered', (as
     ]
   };
   let { result } = renderer.render(mobiledoc);
-  let scripts = result.querySelectorAll('script');
-  assert.ok(!scripts.length, 'no script tag rendered');
-  document.getElementById('qunit-fixture').appendChild(result);
+  let content = outerHTML(result);
+  assert.ok(content.indexOf('script') === -1, 'no script tag rendered');
 });
 
 test('XSS: unexpected markup types are not rendered', (assert) => {
@@ -584,12 +527,9 @@ test('XSS: unexpected markup types are not rendered', (assert) => {
     ]
   };
   let { result } = renderer.render(mobiledoc);
-  let script = result.querySelector('script');
-  assert.ok(!script, 'no script tags rendered');
-  document.getElementById('qunit-fixture').appendChild(result);
+  let content = outerHTML(result);
+  assert.ok(content.indexOf('script') === -1, 'no script tag rendered');
 });
-
-
 
 test('renders a mobiledoc with atom', (assert) => {
   let atomName = 'hello-atom';
@@ -616,7 +556,7 @@ test('renders a mobiledoc with atom', (assert) => {
   renderer = new Renderer({atoms: [atom]});
   let { result: rendered } = renderer.render(mobiledoc);
 
-  let sectionEl = rendered.childNodes[0];
+  let sectionEl = rendered.firstChild;
   assert.equal(sectionEl.textContent, 'Hello Bob');
 });
 
@@ -774,14 +714,91 @@ test('renders a mobiledoc with sectionElementRenderer', (assert) => {
   });
   let renderResult = renderer.render(mobiledoc);
   let { result: rendered } = renderResult;
-  assert.equal(rendered.childNodes.length, 3,
+  assert.equal(childNodesLength(rendered), 3,
                'renders three sections');
-  assert.equal(rendered.childNodes[0].tagName, 'PRE',
+  assert.equal(rendered.firstChild.tagName, 'PRE',
                'renders a pre');
-  assert.equal(rendered.childNodes[0].textContent, 'hello world',
+  assert.equal(rendered.firstChild.textContent, 'hello world',
                'renders the text');
-  assert.equal(rendered.childNodes[1].tagName, 'PRE',
+  assert.equal(rendered.childNodes.item(1).tagName, 'PRE',
                'renders a pre');
-  assert.equal(rendered.childNodes[2].tagName, 'H2',
+  assert.equal(rendered.childNodes.item(2).tagName, 'H2',
                'renders an h2');
 });
+}
+
+module('Unit: Mobiledoc DOM Renderer - 0.3', {
+  beforeEach() {
+    renderer = new Renderer();
+  }
+});
+
+generateTests();
+
+test('teardown removes rendered sections from dom', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [],
+    sections: [
+      [MARKUP_SECTION_TYPE, 'p', [
+        [MARKUP_MARKER_TYPE, [], 0, 'Hello world']
+      ]]
+    ]
+  };
+
+  let { result: rendered, teardown } = renderer.render(mobiledoc);
+  assert.equal(childNodesLength(rendered), 1, 'renders 1 section');
+
+  let fixture = document.getElementById('qunit-fixture');
+  fixture.appendChild(rendered);
+
+  assert.ok(childNodesLength(fixture) === 1, 'precond - result is appended');
+
+  teardown();
+
+  assert.ok(childNodesLength(fixture) === 0, 'rendered result removed after teardown');
+});
+
+test('teardown hook calls registered teardown methods', (assert) => {
+  let cardName = 'title-card';
+  let didTeardown = false;
+
+  let card = {
+    name: cardName,
+    type: 'dom',
+    render({env}) {
+      env.onTeardown(() => didTeardown = true);
+    }
+  };
+
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [
+      [cardName]
+    ],
+    markups: [],
+    sections: [
+      [CARD_SECTION_TYPE, 0]
+    ]
+  };
+
+  renderer = new Renderer({cards: [card]});
+  let { teardown } = renderer.render(mobiledoc);
+
+  assert.ok(!didTeardown, 'teardown not called');
+
+  teardown();
+
+  assert.ok(didTeardown, 'teardown called');
+});
+
+module('Unit: Mobiledoc DOM Renderer w/ SimpleDOM - 0.3', {
+  beforeEach() {
+    renderer = new Renderer({ dom: new SimpleDOM.Document() });
+  }
+});
+
+generateTests();


### PR DESCRIPTION
The DOM renderer, HTML renderer, and AMP renderer have significant duplication. This PR makes the dom renderer codebase SimpleDOM friendly and tested to be so. The HTML renderer and AMP renderer should be re-implemented as wrappers around the DOM renderer.