### PR TITLE
Remove card wrappers

### DIFF
--- a/lib/renderers/0-2.js
+++ b/lib/renderers/0-2.js
@@ -16,7 +16,6 @@ import {
 export const MOBILEDOC_VERSION = '0.2.0';
 
 const IMAGE_SECTION_TAG_NAME = 'img';
-const CARD_ELEMENT_TAG_NAME = 'div';
 
 function createElementFromMarkerType(dom, [tagName, attributes]=['', []]){
   let element = dom.createElement(tagName);
@@ -218,20 +217,12 @@ export default class Renderer {
   renderCardSection([type, name, payload]) {
     let card = this.findCard(name);
 
-    let cardWrapper = this._createCardElement();
     let cardArg = this._createCardArgument(card, payload);
     let rendered = card.render(cardArg);
 
     this._validateCardRender(rendered, card.name);
 
-    if (rendered) {
-      cardWrapper.appendChild(rendered);
-    }
-    return cardWrapper;
-  }
-
-  _createCardElement() {
-    return this.dom.createElement(CARD_ELEMENT_TAG_NAME);
+    return rendered;
   }
 
   _validateCardRender(rendered, cardName) {

--- a/lib/renderers/0-3.js
+++ b/lib/renderers/0-3.js
@@ -21,7 +21,6 @@ import {
 export const MOBILEDOC_VERSION = '0.3.0';
 
 const IMAGE_SECTION_TAG_NAME = 'img';
-const CARD_ELEMENT_TAG_NAME = 'div';
 
 function createElementFromMarkerType(dom, [tagName, attributes]=['', []]){
   let element = dom.createElement(tagName);
@@ -255,20 +254,12 @@ export default class Renderer {
   renderCardSection([type, index]) {
     let { card, payload } = this._findCardByIndex(index);
 
-    let cardWrapper = this._createCardElement();
     let cardArg = this._createCardArgument(card, payload);
     let rendered = card.render(cardArg);
 
     this._validateCardRender(rendered, card.name);
 
-    if (rendered) {
-      cardWrapper.appendChild(rendered);
-    }
-    return cardWrapper;
-  }
-
-  _createCardElement() {
-    return this.dom.createElement(CARD_ELEMENT_TAG_NAME);
+    return rendered;
   }
 
   _validateCardRender(rendered, cardName) {

--- a/tests/unit/renderers/0-2-test.js
+++ b/tests/unit/renderers/0-2-test.js
@@ -191,8 +191,8 @@ test('renders a mobiledoc with built-in image card', (assert) => {
                'renders 1 section');
   let sectionEl = rendered.childNodes.item(0);
 
-  assert.equal(sectionEl.firstChild.tagName, 'IMG');
-  assert.equal(sectionEl.firstChild.src, dataUri);
+  assert.equal(sectionEl.tagName, 'IMG');
+  assert.equal(sectionEl.src, dataUri);
 });
 
 test('render mobiledoc with list section and list items', (assert) => {
@@ -257,9 +257,7 @@ test('renders a mobiledoc with card section', (assert) => {
   renderer = new Renderer({cards: [TitleCard], cardOptions: expectedOptions});
   let { result: rendered } = renderer.render(mobiledoc);
   assert.equal(childNodesLength(rendered), 1, 'renders 1 section');
-  let sectionEl = rendered.firstChild;
-
-  assert.equal(innerHTML(sectionEl), expectedPayload.name);
+  assert.equal(innerHTML(rendered), expectedPayload.name);
 });
 
 test('throws when given invalid card type', (assert) => {
@@ -373,8 +371,8 @@ test('rendering nested mobiledocs in cards', (assert) => {
   assert.equal(childNodesLength(rendered), 1, 'renders 1 section');
   let card = rendered.firstChild;
   assert.equal(childNodesLength(card), 1, 'card has 1 child');
-  assert.equal(card.firstChild.tagName, 'P', 'card has P child');
-  assert.equal(card.firstChild.innerText, 'hello world');
+  assert.equal(card.tagName, 'P', 'card has P child');
+  assert.equal(card.innerText, 'hello world');
 });
 
 test('rendering unknown card without unknownCardHandler throws', (assert) => {

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -194,8 +194,8 @@ test('renders a mobiledoc with built-in image card', (assert) => {
                'renders 1 section');
   let sectionEl = rendered.firstChild;
 
-  assert.equal(sectionEl.firstChild.tagName, 'IMG');
-  assert.equal(sectionEl.firstChild.src, dataUri);
+  assert.equal(sectionEl.tagName, 'IMG');
+  assert.equal(sectionEl.src, dataUri);
 });
 
 test('render mobiledoc with list section and list items', (assert) => {
@@ -262,9 +262,7 @@ test('renders a mobiledoc with card section', (assert) => {
   renderer = new Renderer({cards: [TitleCard], cardOptions: expectedOptions});
   let { result: rendered } = renderer.render(mobiledoc);
   assert.equal(childNodesLength(rendered), 1, 'renders 1 section');
-  let sectionEl = rendered.firstChild;
-
-  assert.equal(innerHTML(sectionEl), expectedPayload.name);
+  assert.equal(innerHTML(rendered), expectedPayload.name);
 });
 
 test('throws when given invalid card type', (assert) => {
@@ -384,8 +382,8 @@ test('rendering nested mobiledocs in cards', (assert) => {
   assert.equal(childNodesLength(rendered), 1, 'renders 1 section');
   let card = rendered.firstChild;
   assert.equal(childNodesLength(card), 1, 'card has 1 child');
-  assert.equal(card.firstChild.tagName, 'P', 'card has P child');
-  assert.equal(card.firstChild.innerText, 'hello world');
+  assert.equal(card.tagName, 'P', 'card has P child');
+  assert.equal(card.innerText, 'hello world');
 });
 
 test('rendering unknown card without unknownCardHandler throws', (assert) => {


### PR DESCRIPTION
Currently, every card is wrapped in a programmatically inaccessible div element.  This can become a styling and performance problem.  The wrapper doesn't seem necessary in a purely rendering context.
