### PR TITLE
Add didRender hooks to match latest mobiledoc-kit

### DIFF
--- a/lib/renderers/0-2.js
+++ b/lib/renderers/0-2.js
@@ -69,6 +69,7 @@ export default class Renderer {
       }
     }
 
+    this._renderCallbacks    = [];
     this._teardownCallbacks  = [];
     this._renderedChildNodes = [];
   }
@@ -86,6 +87,9 @@ export default class Renderer {
         this.root.appendChild(rendered);
       }
     });
+    for (let i = 0; i < this._renderCallbacks.length; i++) {
+      this._renderCallbacks[i]();
+    }
     // maintain a reference to child nodes so they can be cleaned up later by teardown
     this._renderedChildNodes = [];
     let node = this.root.firstChild;
@@ -202,12 +206,17 @@ export default class Renderer {
       name: card.name,
       isInEditor: false,
       dom: this.dom,
+      didRender: (callback) => this._registerRenderCallback(callback),
       onTeardown: (callback) => this._registerTeardownCallback(callback)
     };
 
     let options = this.cardOptions;
 
     return { env, options, payload };
+  }
+
+  _registerRenderCallback(callback) {
+    this._renderCallbacks.push(callback);
   }
 
   _registerTeardownCallback(callback) {

--- a/lib/renderers/0-3.js
+++ b/lib/renderers/0-3.js
@@ -82,6 +82,7 @@ export default class Renderer {
       }
     }
 
+    this._renderCallbacks = [];
     this._teardownCallbacks  = [];
   }
 
@@ -104,6 +105,9 @@ export default class Renderer {
         this.root.appendChild(rendered);
       }
     });
+    for (let i=0; i < this._renderCallbacks.length; i++) {
+      this._renderCallbacks[i]();
+    }
     // maintain a reference to child nodes so they can be cleaned up later by teardown
     this._renderedChildNodes = Array.prototype.slice.call(this.root.childNodes);
     return { result: this.root, teardown: () => this.teardown() };
@@ -239,6 +243,7 @@ export default class Renderer {
       name: card.name,
       isInEditor: false,
       dom: this.dom,
+      didRender: (callback) => this._registerRenderCallback(callback),
       onTeardown: (callback) => this._registerTeardownCallback(callback)
     };
 
@@ -249,6 +254,10 @@ export default class Renderer {
 
   _registerTeardownCallback(callback) {
     this._teardownCallbacks.push(callback);
+  }
+
+  _registerRenderCallback(callback) {
+    this._renderCallbacks.push(callback);
   }
 
   renderCardSection([type, index]) {

--- a/tests/unit/renderers/0-2-test.js
+++ b/tests/unit/renderers/0-2-test.js
@@ -226,7 +226,7 @@ test('render mobiledoc with list section and list items', (assert) => {
 });
 
 test('renders a mobiledoc with card section', (assert) => {
-  assert.expect(7);
+  assert.expect(8);
   let cardName = 'title-card';
   let expectedPayload = { name: 'bob' };
   let expectedOptions = {foo: 'bar'};
@@ -234,10 +234,11 @@ test('renders a mobiledoc with card section', (assert) => {
     name: cardName,
     type: 'dom',
     render({env, options, payload}) {
-      let {name, isInEditor, onTeardown} = env;
+      let {name, isInEditor, onTeardown, didRender} = env;
       assert.equal(name, cardName, 'has name');
       assert.ok(!isInEditor, 'not isInEditor');
       assert.ok(!!onTeardown, 'has onTeardown');
+      assert.ok(!!didRender, 'has didRender');
 
       assert.deepEqual(options, expectedOptions);
       assert.deepEqual(payload, expectedPayload);
@@ -394,7 +395,7 @@ test('rendering unknown card without unknownCardHandler throws', (assert) => {
 });
 
 test('rendering unknown card uses unknownCardHandler', (assert) => {
-  assert.expect(5);
+  assert.expect(6);
 
   let cardName = 'my-card';
   let expectedOptions = {};
@@ -404,6 +405,7 @@ test('rendering unknown card uses unknownCardHandler', (assert) => {
     assert.equal(env.name, cardName, 'name is correct');
     assert.ok(!env.isInEditor, 'not in editor');
     assert.ok(!!env.onTeardown, 'has onTeardown');
+    assert.ok(!!env.didRender, 'has didRender');
 
     assert.deepEqual(options, expectedOptions, 'correct options');
     assert.deepEqual(payload, expectedPayload, 'correct payload');
@@ -637,6 +639,37 @@ test('teardown hook calls registered teardown methods', (assert) => {
   teardown();
 
   assert.ok(didTeardown, 'teardown called');
+});
+
+test('render hook calls registered didRender callbacks', (assert) => {
+  let cardName = 'title-card';
+  let didRender = false;
+
+  let card = {
+    name: cardName,
+    type: 'dom',
+    render({env}) {
+      env.didRender(() => didRender = true);
+    }
+  };
+
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [],
+      [
+        [CARD_SECTION_TYPE, cardName]
+      ]
+    ]
+  };
+
+  renderer = new Renderer({cards: [card]});
+
+  assert.ok(!didRender, 'didRender not called');
+
+  renderer.render(mobiledoc);
+
+  assert.ok(didRender, 'didRender called');
 });
 
 

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -230,7 +230,7 @@ test('render mobiledoc with list section and list items', (assert) => {
 });
 
 test('renders a mobiledoc with card section', (assert) => {
-  assert.expect(8);
+  assert.expect(9);
   let cardName = 'title-card';
   let expectedPayload = { name: 'bob' };
   let expectedOptions = { foo: 'bar' };
@@ -245,6 +245,7 @@ test('renders a mobiledoc with card section', (assert) => {
       assert.equal(env.name, cardName, 'correct name');
       assert.ok(!env.isInEditor, 'isInEditor correct');
       assert.ok(!!env.onTeardown, 'has onTeardown hook');
+      assert.ok(!!env.didRender, 'has didRender hook');
       assert.deepEqual(env.dom, expectedDom, 'env has dom');
 
       return document.createTextNode(payload.name);
@@ -410,7 +411,7 @@ test('rendering unknown card without unknownCardHandler throws', (assert) => {
 });
 
 test('rendering unknown card uses unknownCardHandler', (assert) => {
-  assert.expect(5);
+  assert.expect(6);
 
   let cardName = 'my-card';
   let expectedOptions = {};
@@ -420,6 +421,7 @@ test('rendering unknown card uses unknownCardHandler', (assert) => {
     assert.equal(env.name, cardName, 'name is correct');
     assert.ok(!env.isInEditor, 'not in editor');
     assert.ok(!!env.onTeardown, 'has onTeardown');
+    assert.ok(!!env.didRender, 'has didRender');
 
     assert.deepEqual(options, expectedOptions, 'correct options');
     assert.deepEqual(payload, expectedPayload, 'correct payload');
@@ -828,6 +830,39 @@ test('teardown hook calls registered teardown methods', (assert) => {
   teardown();
 
   assert.ok(didTeardown, 'teardown called');
+});
+
+test('render hook calls registered didRender callbacks', (assert) => {
+  let cardName = 'title-card';
+  let didRender = false;
+
+  let card = {
+    name: cardName,
+    type: 'dom',
+    render({env}) {
+      env.didRender(() => didRender = true);
+    }
+  };
+
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [
+      [cardName]
+    ],
+    markups: [],
+    sections: [
+      [CARD_SECTION_TYPE, 0]
+    ]
+  };
+
+  renderer = new Renderer({cards: [card]});
+
+  assert.ok(!didRender, 'didRender not called');
+
+  renderer.render(mobiledoc);
+
+  assert.ok(!!didRender, 'didRender called');
 });
 
 module('Unit: Mobiledoc DOM Renderer w/ SimpleDOM - 0.3', {


### PR DESCRIPTION
Enables cards that have [didRender](https://github.com/bustlelabs/mobiledoc-kit/pull/382/files) callbacks.