### PR TITLE
Add a markup renderer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,34 @@ var renderer = new MobiledocDOMRenderer({
 var rendered = renderer.render(mobiledoc);
 ```
 
+#### markupElementRenderer
+
+Use this renderer option to customize what inline tags are used when renderin
+a section's content.
+
+```
+var renderer = new MobiledocDOMRenderer({
+  markupElementRenderer: {
+    B: function(_, dom) { return dom.createElement('strong'); },
+    A: function(markerType, dom) {
+      let [tagName, attributes] = markerType;
+      attributes = attributes || [];
+      let element = dom.createElement(tagName);
+
+      for (let i=0,l=attributes.length; i<l; i=i+2) {
+        let propName = attributes[i],
+        propValue = attributes[i+1];
+        element.setAttribute(propName, propValue);
+      }
+
+      element.setAttribute('rel', 'nofollow');
+      return element;
+    }
+  }
+});
+var renderer = renderer.render(mobiledoc);
+```
+
 ### Tests
 
  * `npm test`

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ var renderer = new MobiledocDOMRenderer({
     }
   }
 });
-var renderer = renderer.render(mobiledoc);
+var rendered = renderer.render(mobiledoc);
 ```
 
 ### Tests

--- a/README.md
+++ b/README.md
@@ -110,15 +110,11 @@ a section's content.
 var renderer = new MobiledocDOMRenderer({
   markupElementRenderer: {
     B: function(_, dom) { return dom.createElement('strong'); },
-    A: function(markerType, dom) {
-      let [tagName, attributes] = markerType;
-      attributes = attributes || [];
+    A: function(tagName, dom, attrs={}) {
       let element = dom.createElement(tagName);
 
-      for (let i=0,l=attributes.length; i<l; i=i+2) {
-        let propName = attributes[i],
-        propValue = attributes[i+1];
-        element.setAttribute(propName, propValue);
+      for (let attr in attrs) {
+        element.setAttribute(attr, attrs[attr]);
       }
 
       element.setAttribute('rel', 'nofollow');

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ var rendered = renderer.render(mobiledoc);
 
 #### markupElementRenderer
 
-Use this renderer option to customize what inline tags are used when renderin
+Use this renderer option to customize what inline tags are used when rendering
 a section's content.
 
 ```

--- a/lib/renderer-factory.js
+++ b/lib/renderer-factory.js
@@ -47,6 +47,7 @@
      cardOptions,
      unknownCardHandler,
      unknownAtomHandler,
+     markupElementRenderer,
      sectionElementRenderer,
      dom
    }={}) {
@@ -69,6 +70,7 @@
        cardOptions,
        unknownCardHandler,
        unknownAtomHandler,
+       markupElementRenderer,
        sectionElementRenderer,
        dom
      };

--- a/lib/renderers/0-2.js
+++ b/lib/renderers/0-2.js
@@ -156,12 +156,14 @@ export default class Renderer {
         let markerType = this.markerTypes[openTypes[j]];
         let [tagName] = markerType;
         let lowerCaseTagName = tagName.toLowerCase();
-        if (this.markupElementRenderer[lowerCaseTagName]) {
-          let openedElement = this.markupElementRenderer[lowerCaseTagName](markerType, this.dom);
-          pushElement(openedElement);
-        } else if (isValidMarkerType(tagName)) {
-          let openedElement = createElementFromMarkerType(this.dom, markerType);
-          pushElement(openedElement);
+        if (isValidMarkerType(tagName)) {
+          if (this.markupElementRenderer[lowerCaseTagName]) {
+            let openedElement = this.markupElementRenderer[lowerCaseTagName](markerType, this.dom);
+            pushElement(openedElement);
+          } else {
+            let openedElement = createElementFromMarkerType(this.dom, markerType);
+            pushElement(openedElement);
+          }
         } else {
           closeCount--;
         }

--- a/lib/renderers/0-2.js
+++ b/lib/renderers/0-2.js
@@ -41,6 +41,7 @@ export default class Renderer {
       cards,
       cardOptions,
       unknownCardHandler,
+      markupElementRenderer,
       sectionElementRenderer,
       dom
     } = options;
@@ -65,6 +66,15 @@ export default class Renderer {
       for (let key in sectionElementRenderer) {
         if (sectionElementRenderer.hasOwnProperty(key)) {
           this.sectionElementRenderer[key.toLowerCase()] = sectionElementRenderer[key];
+        }
+      }
+    }
+
+    this.markupElementRenderer = {};
+    if (markupElementRenderer) {
+      for (let key in markupElementRenderer) {
+        if (markupElementRenderer.hasOwnProperty(key)) {
+          this.markupElementRenderer[key.toLowerCase()] = markupElementRenderer[key];
         }
       }
     }
@@ -128,6 +138,12 @@ export default class Renderer {
     let elements = [element];
     let currentElement = element;
 
+    let pushElement = (openedElement) => {
+      currentElement.appendChild(openedElement);
+      elements.push(openedElement);
+      currentElement = openedElement;
+    };
+
     for (let i=0, l=markers.length; i<l; i++) {
       let marker = markers[i];
       let [openTypes, closeCount, text] = marker;
@@ -135,11 +151,13 @@ export default class Renderer {
       for (let j=0, m=openTypes.length; j<m; j++) {
         let markerType = this.markerTypes[openTypes[j]];
         let [tagName] = markerType;
-        if (isValidMarkerType(tagName)) {
+        let lowerCaseTagName = tagName.toLowerCase();
+        if (this.markupElementRenderer[lowerCaseTagName]) {
+          let openedElement = this.markupElementRenderer[lowerCaseTagName](markerType, this.dom);
+          pushElement(openedElement);
+        } else if (isValidMarkerType(tagName)) {
           let openedElement = createElementFromMarkerType(this.dom, markerType);
-          currentElement.appendChild(openedElement);
-          elements.push(openedElement);
-          currentElement = openedElement;
+          pushElement(openedElement);
         } else {
           closeCount--;
         }

--- a/lib/renderers/0-2.js
+++ b/lib/renderers/0-2.js
@@ -12,6 +12,7 @@ import {
   isMarkupSectionElementName,
   isValidMarkerType
 } from '../utils/tag-names';
+import kvReduce from '../utils/kv-reduce';
 
 export const MOBILEDOC_VERSION = '0.2.0';
 
@@ -154,11 +155,12 @@ export default class Renderer {
 
       for (let j=0, m=openTypes.length; j<m; j++) {
         let markerType = this.markerTypes[openTypes[j]];
-        let [tagName] = markerType;
-        let lowerCaseTagName = tagName.toLowerCase();
+        let [tagName, attrs=[]] = markerType;
         if (isValidMarkerType(tagName)) {
+          let lowerCaseTagName = tagName.toLowerCase();
           if (this.markupElementRenderer[lowerCaseTagName]) {
-            let openedElement = this.markupElementRenderer[lowerCaseTagName](markerType, this.dom);
+            let attrObj = attrs.reduce(kvReduce, {});
+            let openedElement = this.markupElementRenderer[lowerCaseTagName](tagName, this.dom, attrObj);
             pushElement(openedElement);
           } else {
             let openedElement = createElementFromMarkerType(this.dom, markerType);

--- a/lib/renderers/0-3.js
+++ b/lib/renderers/0-3.js
@@ -12,6 +12,7 @@ import {
   isMarkupSectionElementName,
   isValidMarkerType
 } from '../utils/tag-names';
+import kvReduce from '../utils/kv-reduce';
 
 import {
   MARKUP_MARKER_TYPE,
@@ -167,11 +168,12 @@ export default class Renderer {
 
       for (let j=0, m=openTypes.length; j<m; j++) {
         let markerType = this.markerTypes[openTypes[j]];
-        let [tagName] = markerType;
+        let [tagName, attrs=[]] = markerType;
         if (isValidMarkerType(tagName)) {
           let lowerCaseTagName = tagName.toLowerCase();
           if (this.markupElementRenderer[lowerCaseTagName]) {
-            let openedElement = this.markupElementRenderer[lowerCaseTagName](markerType, this.dom);
+            let attrObj = attrs.reduce(kvReduce, {});
+            let openedElement = this.markupElementRenderer[lowerCaseTagName](tagName, this.dom, attrObj);
             pushElement(openedElement);
           } else {
             let openedElement = createElementFromMarkerType(this.dom, markerType);

--- a/lib/renderers/0-3.js
+++ b/lib/renderers/0-3.js
@@ -49,6 +49,7 @@ export default class Renderer {
       atoms,
       unknownCardHandler,
       unknownAtomHandler,
+      markupElementRenderer,
       sectionElementRenderer,
       dom
     } = state;
@@ -78,6 +79,15 @@ export default class Renderer {
       for (let key in sectionElementRenderer) {
         if (sectionElementRenderer.hasOwnProperty(key)) {
           this.sectionElementRenderer[key.toLowerCase()] = sectionElementRenderer[key];
+        }
+      }
+    }
+
+    this.markupElementRenderer = {};
+    if (markupElementRenderer) {
+      for (let key in markupElementRenderer) {
+        if (markupElementRenderer.hasOwnProperty(key)) {
+          this.markupElementRenderer[key.toLowerCase()] = markupElementRenderer[key];
         }
       }
     }
@@ -141,6 +151,12 @@ export default class Renderer {
     let elements = [element];
     let currentElement = element;
 
+    let pushElement = (openedElement) => {
+      currentElement.appendChild(openedElement);
+      elements.push(openedElement);
+      currentElement = openedElement;
+    };
+
     for (let i=0, l=markers.length; i<l; i++) {
       let marker = markers[i];
       let [type, openTypes, closeCount, value] = marker;
@@ -148,11 +164,12 @@ export default class Renderer {
       for (let j=0, m=openTypes.length; j<m; j++) {
         let markerType = this.markerTypes[openTypes[j]];
         let [tagName] = markerType;
-        if (isValidMarkerType(tagName)) {
+        if (this.markupElementRenderer[tagName]) {
+          let openedElement = this.markupElementRenderer[tagName](markerType, this.dom);
+          pushElement(openedElement);
+        } else if (isValidMarkerType(tagName)) {
           let openedElement = createElementFromMarkerType(this.dom, markerType);
-          currentElement.appendChild( openedElement);
-          elements.push(openedElement);
-          currentElement = openedElement;
+          pushElement(openedElement);
         } else {
           closeCount--;
         }

--- a/lib/renderers/0-3.js
+++ b/lib/renderers/0-3.js
@@ -168,13 +168,15 @@ export default class Renderer {
       for (let j=0, m=openTypes.length; j<m; j++) {
         let markerType = this.markerTypes[openTypes[j]];
         let [tagName] = markerType;
-        let lowerCaseTagName = tagName.toLowerCase();
-        if (this.markupElementRenderer[lowerCaseTagName]) {
-          let openedElement = this.markupElementRenderer[lowerCaseTagName](markerType, this.dom);
-          pushElement(openedElement);
-        } else if (isValidMarkerType(tagName)) {
-          let openedElement = createElementFromMarkerType(this.dom, markerType);
-          pushElement(openedElement);
+        if (isValidMarkerType(tagName)) {
+          let lowerCaseTagName = tagName.toLowerCase();
+          if (this.markupElementRenderer[lowerCaseTagName]) {
+            let openedElement = this.markupElementRenderer[lowerCaseTagName](markerType, this.dom);
+            pushElement(openedElement);
+          } else {
+            let openedElement = createElementFromMarkerType(this.dom, markerType);
+            pushElement(openedElement);
+          }
         } else {
           closeCount--;
         }

--- a/lib/renderers/0-3.js
+++ b/lib/renderers/0-3.js
@@ -164,8 +164,9 @@ export default class Renderer {
       for (let j=0, m=openTypes.length; j<m; j++) {
         let markerType = this.markerTypes[openTypes[j]];
         let [tagName] = markerType;
-        if (this.markupElementRenderer[tagName]) {
-          let openedElement = this.markupElementRenderer[tagName](markerType, this.dom);
+        let lowerCaseTagName = tagName.toLowerCase();
+        if (this.markupElementRenderer[lowerCaseTagName]) {
+          let openedElement = this.markupElementRenderer[lowerCaseTagName](markerType, this.dom);
           pushElement(openedElement);
         } else if (isValidMarkerType(tagName)) {
           let openedElement = createElementFromMarkerType(this.dom, markerType);

--- a/lib/utils/kv-reduce.js
+++ b/lib/utils/kv-reduce.js
@@ -1,0 +1,13 @@
+/**
+ * Reduces an array into an object of k/v pairs.
+ *
+ * @example
+ * ['#href', '#foo', 'rel', 'nofollow'].reduce(kvReduce, {});
+ * // returns { href: "#foo", rel: "nofollow" };
+ */
+export default function kvReduce(obj, key, i, arr) {
+  if (i % 2 === 0) {
+    obj[key] = arr[i+1];
+  }
+  return obj;
+}

--- a/tests/unit/renderers/0-2-test.js
+++ b/tests/unit/renderers/0-2-test.js
@@ -591,11 +591,10 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
   };
   renderer = new Renderer({
     markupElementRenderer: {
-      A: (markertype, dom) => {
-        let [tagName, attributes] = markertype;
+      A: (tagName, dom, attrs) => {
         let element = dom.createElement('span');
         element.setAttribute('data-tag', tagName);
-        element.setAttribute('data-href', attributes[1]);
+        element.setAttribute('data-href', attrs.href);
         return element;
       }
     }

--- a/tests/unit/renderers/0-2-test.js
+++ b/tests/unit/renderers/0-2-test.js
@@ -614,6 +614,32 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
   assert.equal(rendered.firstChild.childNodes[2].nodeType, 3,
                'renders text nodes as proper type');
 });
+
+test('unexpected markup types are not passed to markup renderer', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    sections: [
+      [
+        ['script'] // invalid
+      ],
+      [
+        [MARKUP_SECTION_TYPE, 'p', [
+          [[0], 1, 'alert("markup XSS")']
+        ]]
+      ]
+    ]
+  };
+  renderer = new Renderer({
+    markupElementRenderer: {
+      A: (tagName, dom) => {
+        return dom.createElement('script');
+      }
+    }
+  });
+  let { result } = renderer.render(mobiledoc);
+  let content = outerHTML(result);
+  assert.ok(content.indexOf('script') === -1, 'no script tag rendered');
+});
 }
 
 module('Unit: Mobiledoc DOM Renderer - 0.2', {

--- a/tests/unit/renderers/0-2-test.js
+++ b/tests/unit/renderers/0-2-test.js
@@ -630,7 +630,7 @@ test('unexpected markup types are not passed to markup renderer', (assert) => {
   };
   renderer = new Renderer({
     markupElementRenderer: {
-      A: (tagName, dom) => {
+      SCRIPT: (tagName, dom) => {
         return dom.createElement('script');
       }
     }

--- a/tests/unit/renderers/0-2-test.js
+++ b/tests/unit/renderers/0-2-test.js
@@ -571,6 +571,47 @@ test('renders a mobiledoc with sectionElementRenderer', (assert) => {
                'renders an h2');
 });
 
+test('renders a mobiledoc with markupElementRenderer', (assert) => {
+  let mobiledoc = {
+    "version": MOBILEDOC_VERSION,
+    "sections": [
+      [
+        ["A", [ "href", "#foo" ]]
+      ],
+      [
+        [MARKUP_SECTION_TYPE, "p", [
+          [[], 0, "Lorem ipsum "],
+          [[0], 1, "dolor"],
+          [[], 0, " sit amet."]]
+        ]
+      ]
+    ]
+  };
+  renderer = new Renderer({
+    markupElementRenderer: {
+      A: (markertype, dom) => {
+        let [tagName, attributes] = markertype;
+        let element = dom.createElement('span');
+        element.setAttribute('data-tag', tagName);
+        element.setAttribute('data-href', attributes[1]);
+        return element;
+      }
+    }
+  });
+  let renderResult = renderer.render(mobiledoc);
+  let { result: rendered } = renderResult;
+
+  assert.equal(rendered.firstChild.childNodes[1].textContent, 'dolor',
+               'renders text inside of marker');
+  assert.equal(rendered.firstChild.childNodes[1].tagName, 'SPAN',
+               'transforms markup nodes');
+  assert.propEqual(rendered.firstChild.childNodes[1].dataset, {tag: "A", href: "#foo"},
+                   'passes original tag and attributes to transform');
+  assert.equal(rendered.firstChild.childNodes[0].textContent, 'Lorem ipsum ',
+               'renders plain text nodes');
+  assert.equal(rendered.firstChild.childNodes[2].nodeType, 3,
+               'renders text nodes as proper type');
+});
 }
 
 module('Unit: Mobiledoc DOM Renderer - 0.2', {

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -779,7 +779,7 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
   };
   renderer = new Renderer({
     markupElementRenderer: {
-      a: (markertype, dom) => {
+      A: (markertype, dom) => {
         let [tagName, attributes] = markertype;
         let element = dom.createElement('span');
         element.setAttribute('data-tag', tagName);
@@ -791,14 +791,16 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
   let renderResult = renderer.render(mobiledoc);
   let { result: rendered } = renderResult;
 
-  assert.equal(rendered.firstChild.childNodes[0].textContent, 'Lorem ipsum ',
-               'renders text');
+  assert.equal(rendered.firstChild.childNodes[1].textContent, 'dolor',
+               'renders text inside of marker');
   assert.equal(rendered.firstChild.childNodes[1].tagName, 'SPAN',
                'transforms markup nodes');
   assert.propEqual(rendered.firstChild.childNodes[1].dataset, {tag: "a", href: "#foo"},
                    'passes original tag and attributes to transform');
+  assert.equal(rendered.firstChild.childNodes[0].textContent, 'Lorem ipsum ',
+               'renders plain text nodes');
   assert.equal(rendered.firstChild.childNodes[2].nodeType, 3,
-               'renders text nodes as text nodes');
+               'renders text nodes as proper type');
 });
 }
 

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -804,6 +804,32 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
   assert.equal(rendered.firstChild.childNodes[2].nodeType, 3,
                'renders text nodes as proper type');
 });
+
+test('unexpected markup types are not handled by markup renderer', (assert) => {
+  let mobiledoc = {
+    version: MOBILEDOC_VERSION,
+    atoms: [],
+    cards: [],
+    markups: [
+      ['script']
+    ],
+    sections: [
+      [MARKUP_SECTION_TYPE, 'p', [
+        [MARKUP_MARKER_TYPE, [0], 1, 'alert("markup XSS")']
+      ]]
+    ]
+  };
+  renderer = new Renderer({
+    markupElementRenderer: {
+      SCRIPT: (markerType, dom) => {
+        return dom.createElement('script');
+      }
+    }
+  });
+  let { result } = renderer.render(mobiledoc);
+  let content = outerHTML(result);
+  assert.ok(content.indexOf('script') === -1, 'no script tag rendered');
+});
 }
 
 module('Unit: Mobiledoc DOM Renderer - 0.3', {

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -781,11 +781,10 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
   };
   renderer = new Renderer({
     markupElementRenderer: {
-      A: (markertype, dom) => {
-        let [tagName, attributes] = markertype;
+      A: (tagName, dom, attrs) => {
         let element = dom.createElement('span');
         element.setAttribute('data-tag', tagName);
-        element.setAttribute('data-href', attributes[1]);
+        element.setAttribute('data-href', attrs.href);
         return element;
       }
     }

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -760,6 +760,46 @@ test('renders a mobiledoc with sectionElementRenderer', (assert) => {
   assert.equal(rendered.childNodes.item(2).tagName, 'H2',
                'renders an h2');
 });
+
+test('renders a mobiledoc with markupElementRenderer', (assert) => {
+  let mobiledoc = {
+    "version": MOBILEDOC_VERSION,
+    "atoms": [],
+    "cards": [],
+    "markups": [
+      ["a", [ "href", "#foo" ]]
+    ],
+    "sections": [
+      [MARKUP_SECTION_TYPE, "p", [
+        [MARKUP_MARKER_TYPE, [], 0, "Lorem ipsum "],
+        [MARKUP_MARKER_TYPE, [0], 1, "dolor"],
+        [MARKUP_MARKER_TYPE, [], 0, " sit amet."]]
+      ]
+    ]
+  };
+  renderer = new Renderer({
+    markupElementRenderer: {
+      a: (markertype, dom) => {
+        let [tagName, attributes] = markertype;
+        let element = dom.createElement('span');
+        element.setAttribute('data-tag', tagName);
+        element.setAttribute('data-href', attributes[1]);
+        return element;
+      }
+    }
+  });
+  let renderResult = renderer.render(mobiledoc);
+  let { result: rendered } = renderResult;
+
+  assert.equal(rendered.firstChild.childNodes[0].textContent, 'Lorem ipsum ',
+               'renders text');
+  assert.equal(rendered.firstChild.childNodes[1].tagName, 'SPAN',
+               'transforms markup nodes');
+  assert.propEqual(rendered.firstChild.childNodes[1].dataset, {tag: "a", href: "#foo"},
+                   'passes original tag and attributes to transform');
+  assert.equal(rendered.firstChild.childNodes[2].nodeType, 3,
+               'renders text nodes as text nodes');
+});
 }
 
 module('Unit: Mobiledoc DOM Renderer - 0.3', {


### PR DESCRIPTION
Addresses #24.

There's room here to combine the section and markup renderers into a single object, if you're open to it. I think the unified signature would be `(tagName, dom, attributes=[])`:

  - The `sectionElementRenderer` signature wouldn't change, and might even be extended to make use of the optional `attributes` param.
  - Internally, `markerType` is structured as `[tagName, attributes=[]]` so it's just a matter of exploding that array before passing it on to the renderer.