### PR TITLE
Add renderer context to custom section and markup renderers

### DIFF
--- a/lib/renderers/0-2.js
+++ b/lib/renderers/0-2.js
@@ -158,9 +158,10 @@ export default class Renderer {
         let [tagName, attrs=[]] = markerType;
         if (isValidMarkerType(tagName)) {
           let lowerCaseTagName = tagName.toLowerCase();
-          if (this.markupElementRenderer[lowerCaseTagName]) {
+          let customRenderer = this.markupElementRenderer[lowerCaseTagName];
+          if (customRenderer) {
             let attrObj = attrs.reduce(kvReduce, {});
-            let openedElement = this.markupElementRenderer[lowerCaseTagName](tagName, this.dom, attrObj);
+            let openedElement = customRenderer.call(this, tagName, this.dom, attrObj);
             pushElement(openedElement);
           } else {
             let openedElement = createElementFromMarkerType(this.dom, markerType);
@@ -273,8 +274,9 @@ export default class Renderer {
 
     let element;
     let lowerCaseTagName = tagName.toLowerCase();
-    if (this.sectionElementRenderer[lowerCaseTagName]) {
-      element = this.sectionElementRenderer[lowerCaseTagName](tagName, this.dom);
+    let customRenderer = this.sectionElementRenderer[lowerCaseTagName];
+    if (customRenderer) {
+      element = customRenderer.call(this, tagName, this.dom);
     } else if (isMarkupSectionElementName(tagName)) {
       element = this.dom.createElement(tagName);
     } else {

--- a/lib/renderers/0-3.js
+++ b/lib/renderers/0-3.js
@@ -171,9 +171,10 @@ export default class Renderer {
         let [tagName, attrs=[]] = markerType;
         if (isValidMarkerType(tagName)) {
           let lowerCaseTagName = tagName.toLowerCase();
-          if (this.markupElementRenderer[lowerCaseTagName]) {
+          let customRenderer = this.markupElementRenderer[lowerCaseTagName];
+          if (customRenderer) {
             let attrObj = attrs.reduce(kvReduce, {});
-            let openedElement = this.markupElementRenderer[lowerCaseTagName](tagName, this.dom, attrObj);
+            let openedElement = customRenderer.call(this, tagName, this.dom, attrObj);
             pushElement(openedElement);
           } else {
             let openedElement = createElementFromMarkerType(this.dom, markerType);
@@ -377,8 +378,9 @@ export default class Renderer {
 
     let element;
     let lowerCaseTagName = tagName.toLowerCase();
-    if (this.sectionElementRenderer[lowerCaseTagName]) {
-      element = this.sectionElementRenderer[lowerCaseTagName](tagName, this.dom);
+    let customRenderer = this.sectionElementRenderer[lowerCaseTagName];
+    if (customRenderer) {
+      element = customRenderer.call(this, tagName, this.dom);
     } else if (isMarkupSectionElementName(tagName)) {
       element = this.dom.createElement(tagName);
     } else {

--- a/tests/unit/renderers/0-2-test.js
+++ b/tests/unit/renderers/0-2-test.js
@@ -578,7 +578,7 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
     "version": MOBILEDOC_VERSION,
     "sections": [
       [
-        ["A", [ "href", "#foo" ]]
+        ["A", [ "href", "https://www.google.com" ]]
       ],
       [
         [MARKUP_SECTION_TYPE, "p", [
@@ -591,13 +591,17 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
   };
   renderer = new Renderer({
     markupElementRenderer: {
-      A: (tagName, dom, attrs) => {
+      A: function(tagName, dom, attrs) {
         let element = dom.createElement('span');
         element.setAttribute('data-tag', tagName);
         element.setAttribute('data-href', attrs.href);
+        if (attrs.href.indexOf(this.cardOptions.host) === -1) {
+          element.setAttribute('target', '_blank');
+        }
         return element;
       }
-    }
+    },
+    cardOptions: { host: 'https://www.bustle.com' }
   });
   let renderResult = renderer.render(mobiledoc);
   let { result: rendered } = renderResult;
@@ -606,8 +610,10 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
                'renders text inside of marker');
   assert.equal(rendered.firstChild.childNodes[1].tagName, 'SPAN',
                'transforms markup nodes');
-  assert.propEqual(rendered.firstChild.childNodes[1].dataset, {tag: "A", href: "#foo"},
+  assert.propEqual(rendered.firstChild.childNodes[1].dataset, {tag: "A", href: "https://www.google.com"},
                    'passes original tag and attributes to transform');
+  assert.equal(rendered.firstChild.childNodes[1].attributes.target.value, '_blank',
+               'markupElementRenderer context is the Renderer');
   assert.equal(rendered.firstChild.childNodes[0].textContent, 'Lorem ipsum ',
                'renders plain text nodes');
   assert.equal(rendered.firstChild.childNodes[2].nodeType, 3,

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -769,7 +769,7 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
     "atoms": [],
     "cards": [],
     "markups": [
-      ["a", [ "href", "#foo" ]]
+      ["a", [ "href", "https://www.google.com" ]]
     ],
     "sections": [
       [MARKUP_SECTION_TYPE, "p", [
@@ -781,13 +781,17 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
   };
   renderer = new Renderer({
     markupElementRenderer: {
-      A: (tagName, dom, attrs) => {
+      A: function(tagName, dom, attrs) {
         let element = dom.createElement('span');
         element.setAttribute('data-tag', tagName);
         element.setAttribute('data-href', attrs.href);
+        if (attrs.href.indexOf(this.cardOptions.host) === -1) {
+          element.setAttribute('target', '_blank');
+        }
         return element;
       }
-    }
+    },
+    cardOptions: { host: 'https://www.bustle.com' }
   });
   let renderResult = renderer.render(mobiledoc);
   let { result: rendered } = renderResult;
@@ -796,8 +800,10 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
                'renders text inside of marker');
   assert.equal(rendered.firstChild.childNodes[1].tagName, 'SPAN',
                'transforms markup nodes');
-  assert.propEqual(rendered.firstChild.childNodes[1].dataset, {tag: "a", href: "#foo"},
+  assert.propEqual(rendered.firstChild.childNodes[1].dataset, {tag: "a", href: "https://www.google.com"},
                    'passes original tag and attributes to transform');
+  assert.equal(rendered.firstChild.childNodes[1].attributes.target.value, '_blank',
+               'markupElementRenderer context is the Renderer');
   assert.equal(rendered.firstChild.childNodes[0].textContent, 'Lorem ipsum ',
                'renders plain text nodes');
   assert.equal(rendered.firstChild.childNodes[2].nodeType, 3,


### PR DESCRIPTION
Allows you to access the Renderer itself when inside `sectionElementRenderer` and `markupElementRenderer`
