### PR TITLE
Pass `cardOptions` to custom renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ var renderer = new MobiledocDOMRenderer({
   sectionElementRenderer: {
     P: function(_, dom) { return dom.createElement('span'); },
     H1: function(_, dom) { return dom.createElement('h2'); },
-    H2: function(tagName, dom) {
+    H2: function(tagName, dom, cardOptions) {
       var element = dom.createElement(tagName);
       element.setAttribute('class', 'subheadline');
       return element;
@@ -114,7 +114,7 @@ a section's content.
 var renderer = new MobiledocDOMRenderer({
   markupElementRenderer: {
     B: function(_, dom) { return dom.createElement('strong'); },
-    A: function(tagName, dom, attrs={}) {
+    A: function(tagName, dom, attrs={}, cardOptions) {
       let element = dom.createElement(tagName);
 
       for (let attr in attrs) {

--- a/lib/renderers/0-2.js
+++ b/lib/renderers/0-2.js
@@ -160,7 +160,7 @@ export default class Renderer {
           let lowerCaseTagName = tagName.toLowerCase();
           if (this.markupElementRenderer[lowerCaseTagName]) {
             let attrObj = attrs.reduce(kvReduce, {});
-            let openedElement = this.markupElementRenderer[lowerCaseTagName](tagName, this.dom, attrObj);
+            let openedElement = this.markupElementRenderer[lowerCaseTagName](tagName, this.dom, attrObj, this.cardOptions);
             pushElement(openedElement);
           } else {
             let openedElement = createElementFromMarkerType(this.dom, markerType);
@@ -274,7 +274,7 @@ export default class Renderer {
     let element;
     let lowerCaseTagName = tagName.toLowerCase();
     if (this.sectionElementRenderer[lowerCaseTagName]) {
-      element = this.sectionElementRenderer[lowerCaseTagName](tagName, this.dom);
+      element = this.sectionElementRenderer[lowerCaseTagName](tagName, this.dom, this.cardOptions);
     } else if (isMarkupSectionElementName(tagName)) {
       element = this.dom.createElement(tagName);
     } else {

--- a/lib/renderers/0-3.js
+++ b/lib/renderers/0-3.js
@@ -173,7 +173,7 @@ export default class Renderer {
           let lowerCaseTagName = tagName.toLowerCase();
           if (this.markupElementRenderer[lowerCaseTagName]) {
             let attrObj = attrs.reduce(kvReduce, {});
-            let openedElement = this.markupElementRenderer[lowerCaseTagName](tagName, this.dom, attrObj);
+            let openedElement = this.markupElementRenderer[lowerCaseTagName](tagName, this.dom, attrObj, this.cardOptions);
             pushElement(openedElement);
           } else {
             let openedElement = createElementFromMarkerType(this.dom, markerType);
@@ -378,7 +378,7 @@ export default class Renderer {
     let element;
     let lowerCaseTagName = tagName.toLowerCase();
     if (this.sectionElementRenderer[lowerCaseTagName]) {
-      element = this.sectionElementRenderer[lowerCaseTagName](tagName, this.dom);
+      element = this.sectionElementRenderer[lowerCaseTagName](tagName, this.dom, this.cardOptions);
     } else if (isMarkupSectionElementName(tagName)) {
       element = this.dom.createElement(tagName);
     } else {

--- a/tests/unit/renderers/0-2-test.js
+++ b/tests/unit/renderers/0-2-test.js
@@ -614,6 +614,50 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
                'renders text nodes as proper type');
 });
 
+test('passes cardOptions to markupElementRenderer and sectionElementRenderer', (assert) => {
+  let passedSectionCardOptions, passedMarkupCardOptions;
+  let cardOptions = {};
+
+  let mobiledoc = {
+    "version": MOBILEDOC_VERSION,
+    "sections": [
+      [
+        ["A", [ "href", "#foo" ]]
+      ],
+      [
+        [MARKUP_SECTION_TYPE, "p", [
+          [[], 0, "Lorem ipsum "],
+          [[0], 1, "dolor"],
+          [[], 0, " sit amet."]]
+        ]
+      ]
+    ]
+  };
+  renderer = new Renderer({
+    cardOptions,
+    markupElementRenderer: {
+      A: (tagName, dom, attrs, cardOptions) => {
+        passedMarkupCardOptions = cardOptions;
+        return dom.createElement('a');
+      }
+    },
+    sectionElementRenderer: {
+      P: (tagName, dom, cardOptions) => {
+        passedSectionCardOptions = cardOptions;
+        return dom.createElement('p');
+      }
+    }
+  });
+
+  renderer.render(mobiledoc);
+
+  assert.ok(!!passedSectionCardOptions, 'passes cardOptions to sectionElementRenderer');
+  assert.ok(!!passedMarkupCardOptions, 'passes cardOptions to markupElementRenderer');
+  assert.deepEqual(passedSectionCardOptions, cardOptions);
+  assert.deepEqual(passedMarkupCardOptions, cardOptions);
+});
+
+
 test('unexpected markup types are not passed to markup renderer', (assert) => {
   let mobiledoc = {
     version: MOBILEDOC_VERSION,

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -804,6 +804,49 @@ test('renders a mobiledoc with markupElementRenderer', (assert) => {
                'renders text nodes as proper type');
 });
 
+test('passes cardOptions to markupElementRenderer and sectionElementRenderer', (assert) => {
+  let passedSectionCardOptions, passedMarkupCardOptions;
+  let cardOptions = {};
+
+  let mobiledoc = {
+    "version": MOBILEDOC_VERSION,
+    "atoms": [],
+    "cards": [],
+    "markups": [
+      ["a", [ "href", "#foo" ]]
+    ],
+    "sections": [
+      [MARKUP_SECTION_TYPE, "p", [
+        [MARKUP_MARKER_TYPE, [], 0, "Lorem ipsum "],
+        [MARKUP_MARKER_TYPE, [0], 1, "dolor"],
+        [MARKUP_MARKER_TYPE, [], 0, " sit amet."]]
+      ]
+    ]
+  };
+  renderer = new Renderer({
+    cardOptions,
+    markupElementRenderer: {
+      A: (tagName, dom, attrs, cardOptions) => {
+        passedMarkupCardOptions = cardOptions;
+        return dom.createElement('a');
+      }
+    },
+    sectionElementRenderer: {
+      P: (tagName, dom, cardOptions) => {
+        passedSectionCardOptions = cardOptions;
+        return dom.createElement('p');
+      }
+    }
+  });
+
+  renderer.render(mobiledoc);
+
+  assert.ok(!!passedSectionCardOptions, 'passes cardOptions to sectionElementRenderer');
+  assert.ok(!!passedMarkupCardOptions, 'passes cardOptions to markupElementRenderer');
+  assert.deepEqual(passedSectionCardOptions, cardOptions);
+  assert.deepEqual(passedMarkupCardOptions, cardOptions);
+});
+
 test('unexpected markup types are not handled by markup renderer', (assert) => {
   let mobiledoc = {
     version: MOBILEDOC_VERSION,


### PR DESCRIPTION
Passes `cardOptions` as the final argument to `markupElementRenderer`
and `sectionElementRenderer`.