### PR TITLE
fallback to checking for protocol in url string when parsing fails

### DIFF
--- a/lib/utils/sanitization-utils.js
+++ b/lib/utils/sanitization-utils.js
@@ -24,17 +24,35 @@ function getProtocol(url) {
     if (typeof url === 'string') {
       protocol = nodeURL.parse(url).protocol;
     }
-    return (protocol === null) ? ':' : protocol;
+    return protocol;
   } else {
-    throw new Error('Mobiledoc DOM Renderer is unable to sanitize href tags in this environment');
+    // unknown env where we cannot use a pre-existing url parser,
+    // such as Fastboot's VM Sandbox
+    return null;
   }
 }
 
-function sanitizeHref(url) {
+function urlStartsWithBadProtocol(url) {
+  for (let i=0; i < badProtocols.length; i++) {
+    if (url.indexOf(badProtocols[i]) === 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function urlHasBadProtocol(url) {
   let protocol = getProtocol(url);
-  if (includes(badProtocols, protocol)) {
+
+  return (protocol && includes(badProtocols, url));
+}
+
+function sanitizeHref(url) {
+  if (urlHasBadProtocol(url) || urlStartsWithBadProtocol(url)) {
     return `unsafe:${url}`;
   }
+
   return url;
 }
 


### PR DESCRIPTION
Some environments are neither dom nor node (for instance, ember-fastboot
will run mobiledoc-dom-renderer in VM Sandbox that defines window but
not module.require). In those cases, when sanitizing hrefs fall back to
checking if the url starts with one of the bad protocols.

fixes #48 