### PR TITLE
Remove markupSanitizer in favor of markupElementRenderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,34 +129,15 @@ var renderer = new MobiledocDOMRenderer({
 var rendered = renderer.render(mobiledoc);
 ```
 
-#### markupSanitizer
+#### Attribute Sanitization (XSS Protection)
 
-Use this renderer option to customize how markup attribute values are sanitized.
-The renderer's default markupSanitizer only sanitizes `href` values, prefixing
-unsafe values with the string `"unsafe:"`. All other attribute values are
-passed through unchanged.
-
-To change this behavior, pass your own markupSanitizer function when
-instantiating the renderer. If your markupSanitizer function returns a string,
-that value will be used when rendering. If it returns a falsy value, the
-renderer's default markupSanitizer will be used.
-
-```
-var renderer = new MobiledocDOMRenderer({
-  markupSanitizer: function({tagName, attributeName, attributeValue}) {
-    // This function will be called for every attribute on every markup.
-    // Return a sanitized attributeValue or undefined (in which case the
-    // default sanitizer will be used)
-  }
-});
-```
-
-The default sanitization of href values uses an environment-appropriate url
-parser if it can find one. It's unlikely, but if the renderer is in an
-environment where it cannot determine a url parser it will throw. (This can
-happen when running the renderer in a VM Sandbox, like ember-cli-fastboot
-does.) In this case you must supply a custom markupSanitizer that can handle
-`href` sanitization.
+Mobiledoc DOM Renderer sanitizes the `href` attribute of 'A' markups, prefixing
+the string `unsafe:` on potentially unsafe urls. It determines an environment-
+appropriate URL protocol parser. In rare cases it may be unable to determine one
+(this can happen when running the renderer in a Node VM Sandbox, like ember-cli-
+fastboot does), and will throw in that case. To fix this, you can provide a
+custom markupElementRenderer for the 'A' tag that will be used instead of the
+default.
 
 ### Tests
 

--- a/lib/renderers/0-2.js
+++ b/lib/renderers/0-2.js
@@ -15,7 +15,6 @@ import {
   reduceAttributes
 } from '../utils/sanitization-utils';
 import {
-  createMarkupSanitizerWithFallback,
   defaultSectionElementRenderer,
   defaultMarkupElementRenderer
 } from '../utils/render-utils';
@@ -38,8 +37,7 @@ export default class Renderer {
       unknownCardHandler,
       markupElementRenderer,
       sectionElementRenderer,
-      dom,
-      markupSanitizer
+      dom
     } = options;
     let {
       version,
@@ -56,7 +54,6 @@ export default class Renderer {
     this.cards              = cards;
     this.cardOptions        = cardOptions;
     this.unknownCardHandler = unknownCardHandler || this._defaultUnknownCardHandler;
-    this.markupSanitizer    = createMarkupSanitizerWithFallback(markupSanitizer);
 
     this.sectionElementRenderer = {
       '__default__': defaultSectionElementRenderer
@@ -169,7 +166,7 @@ export default class Renderer {
    */
   renderMarkupElement(tagName, attrs) {
     tagName = tagName.toLowerCase();
-    attrs   = this.sanitizeAttributes(tagName, reduceAttributes(attrs));
+    attrs   = reduceAttributes(attrs);
 
     let renderer = this.markupElementRendererFor(tagName);
     return renderer(tagName, this.dom, attrs);
@@ -178,21 +175,6 @@ export default class Renderer {
   markupElementRendererFor(tagName) {
     return this.markupElementRenderer[tagName] ||
       this.markupElementRenderer.__default__;
-  }
-
-  sanitizeAttributes(tagName, attrsObj) {
-    let sanitized = {};
-
-    Object.keys(attrsObj).forEach(attributeName => {
-      let attributeValue = attrsObj[attributeName];
-      sanitized[attributeName] = this.sanitizeAttribute({tagName, attributeName, attributeValue});
-    });
-
-    return sanitized;
-  }
-
-  sanitizeAttribute({tagName, attributeName, attributeValue}) {
-    return this.markupSanitizer({tagName, attributeName, attributeValue});
   }
 
   renderListItem(markers) {

--- a/lib/renderers/0-3.js
+++ b/lib/renderers/0-3.js
@@ -15,7 +15,6 @@ import {
   reduceAttributes
 } from '../utils/sanitization-utils';
 import {
-  createMarkupSanitizerWithFallback,
   defaultSectionElementRenderer,
   defaultMarkupElementRenderer
 } from '../utils/render-utils';
@@ -52,8 +51,7 @@ export default class Renderer {
       unknownAtomHandler,
       markupElementRenderer,
       sectionElementRenderer,
-      dom,
-      markupSanitizer
+      dom
     } = state;
     let {
       version,
@@ -75,7 +73,6 @@ export default class Renderer {
     this.cardOptions        = cardOptions;
     this.unknownCardHandler = unknownCardHandler || this._defaultUnknownCardHandler;
     this.unknownAtomHandler = unknownAtomHandler || this._defaultUnknownAtomHandler;
-    this.markupSanitizer    = createMarkupSanitizerWithFallback(markupSanitizer);
 
     this.sectionElementRenderer = {
       '__default__': defaultSectionElementRenderer
@@ -198,7 +195,7 @@ export default class Renderer {
    */
   renderMarkupElement(tagName, attrs) {
     tagName = tagName.toLowerCase();
-    attrs   = this.sanitizeAttributes(tagName, reduceAttributes(attrs));
+    attrs   = reduceAttributes(attrs);
 
     let renderer = this.markupElementRendererFor(tagName);
     return renderer(tagName, this.dom, attrs);
@@ -207,21 +204,6 @@ export default class Renderer {
   markupElementRendererFor(tagName) {
     return this.markupElementRenderer[tagName] ||
       this.markupElementRenderer.__default__;
-  }
-
-  sanitizeAttributes(tagName, attrsObj) {
-    let sanitized = {};
-
-    Object.keys(attrsObj).forEach(attributeName => {
-      let attributeValue = attrsObj[attributeName];
-      sanitized[attributeName] = this.sanitizeAttribute({tagName, attributeName, attributeValue});
-    });
-
-    return sanitized;
-  }
-
-  sanitizeAttribute({tagName, attributeName, attributeValue}) {
-    return this.markupSanitizer({tagName, attributeName, attributeValue});
   }
 
   renderListItem(markers) {

--- a/lib/utils/render-utils.js
+++ b/lib/utils/render-utils.js
@@ -5,27 +5,6 @@ import {
   sanitizeHref
 } from './sanitization-utils';
 
-function defaultMarkupSanitizer({tagName, attributeName, attributeValue}) {
-  if (tagName === 'a' && attributeName === 'href') {
-    return sanitizeHref(attributeValue);
-  } else {
-    return attributeValue;
-  }
-}
-
-/*
- * return a sanitizer function that first uses the passed sanitizer
- * (if present), and then uses the default sanitizer if that didn't return
- * a string
- */
-export function createMarkupSanitizerWithFallback(sanitizer) {
-  if (sanitizer) {
-    return (...args) => sanitizer(...args) || defaultMarkupSanitizer(...args);
-  } else {
-    return defaultMarkupSanitizer;
-  }
-}
-
 export function defaultSectionElementRenderer(tagName, dom) {
   let element;
   if (isMarkupSectionElementName(tagName)) {
@@ -38,10 +17,20 @@ export function defaultSectionElementRenderer(tagName, dom) {
   return element;
 }
 
+function sanitizeAttribute(tagName, attrName, attrValue) {
+  if (tagName === 'a' && attrName === 'href') {
+    return sanitizeHref(attrValue);
+  } else {
+    return attrValue;
+  }
+}
+
 export function defaultMarkupElementRenderer(tagName, dom, attrsObj) {
   let element = dom.createElement(tagName);
-  Object.keys(attrsObj).forEach(key => {
-    element.setAttribute(key, attrsObj[key]);
+  Object.keys(attrsObj).forEach(attrName => {
+    let attrValue = attrsObj[attrName];
+    attrValue = sanitizeAttribute(tagName, attrName, attrValue);
+    element.setAttribute(attrName, attrValue);
   });
   return element;
 }

--- a/lib/utils/sanitization-utils.js
+++ b/lib/utils/sanitization-utils.js
@@ -26,7 +26,10 @@ function getProtocol(url) {
     }
     return (protocol === null) ? ':' : protocol;
   } else {
-    throw new Error('Mobiledoc DOM Renderer is unable to sanitize href tags in this environment');
+    throw new Error(
+      'Mobiledoc DOM Renderer is unable to sanitize href tags in this environment.' +
+      'Provide a markupElementRenderer for the \'A\' tag.'
+    );
   }
 }
 

--- a/tests/unit/renderers/0-2-test.js
+++ b/tests/unit/renderers/0-2-test.js
@@ -557,65 +557,6 @@ test('XSS: links with dangerous href values are not rendered', (assert) => {
   assert.equal(content, `<p><a href="unsafe:${escapeQuotes(unsafeHref)}">link text</a>plain text</p>`);
 });
 
-test('renderer delegates to provided "markupSanitizer"', function(assert) {
-  let called = 0;
-
-  let markupSanitizer = ({tagName, attributeName, attributeValue}) => {
-    called++;
-    return attributeValue + 'changed';
-  };
-
-  let renderer = new Renderer({markupSanitizer});
-
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [
-        ["a", [ "href", 'http://google.com/' ]]
-      ],
-      [
-        [MARKUP_SECTION_TYPE, "p", [
-          [[0], 1, "hello world"]
-        ]]
-      ]
-    ]
-  };
-  let { result } = renderer.render(mobiledoc);
-  let content = outerHTML(result);
-  assert.equal(content, `<p><a href="http://google.com/changed">hello world</a></p>`);
-  assert.equal(called, 1, 'markupSanitizer called');
-});
-
-test('when markupSanitizer returns nothing, default sanitizer is used', function(assert) {
-  let called = 0;
-  let unsafeHref = 'javascript:evil'; // jshint ignore:line
-
-  let markupSanitizer = () => {
-    called++;
-    return;
-  };
-
-  let renderer = new Renderer({markupSanitizer});
-
-  let mobiledoc = {
-    version: MOBILEDOC_VERSION,
-    sections: [
-      [
-        ["a", [ "href", unsafeHref ]]
-      ],
-      [
-        [MARKUP_SECTION_TYPE, "p", [
-          [[0], 1, 'hello world']
-        ]]
-      ]
-    ]
-  };
-  let { result } = renderer.render(mobiledoc);
-  let content = outerHTML(result);
-  assert.equal(content, `<p><a href="unsafe:${unsafeHref}">hello world</a></p>`);
-  assert.equal(called, 1, 'markupSanitizer called');
-});
-
 test('renders a mobiledoc with sectionElementRenderer', (assert) => {
   let mobiledoc = {
     version: MOBILEDOC_VERSION,

--- a/tests/unit/renderers/0-3-test.js
+++ b/tests/unit/renderers/0-3-test.js
@@ -541,41 +541,6 @@ test('XSS: "a" markups are sanitized if upper or lower case', function(assert) {
   });
 });
 
-test('renderer delegates to provided "markupSanitizer"', function(assert) {
-  let called = 0;
-
-  let markupSanitizer = ({tagName, attributeName, attributeValue}) => {
-    called++;
-    return attributeValue + 'changed';
-  };
-
-  let renderer = new Renderer({markupSanitizer});
-
-  let mobiledoc = createSimpleMobiledoc({markup: ['a', ['href', 'http://google.com/']]});
-  let { result } = renderer.render(mobiledoc);
-  let content = outerHTML(result);
-  assert.equal(content, `<p><a href="http://google.com/changed">hello world</a></p>`);
-  assert.equal(called, 1, 'markupSanitizer called');
-});
-
-test('when markupSanitizer returns nothing, default sanitizer is used', function(assert) {
-  let called = 0;
-  let unsafeHref = 'javascript:evil'; // jshint ignore:line
-
-  let markupSanitizer = () => {
-    called++;
-    return;
-  };
-
-  let renderer = new Renderer({markupSanitizer});
-
-  let mobiledoc = createSimpleMobiledoc({markup: ['a', ['href', unsafeHref]]});
-  let { result } = renderer.render(mobiledoc);
-  let content = outerHTML(result);
-  assert.equal(content, `<p><a href="unsafe:${unsafeHref}">hello world</a></p>`);
-  assert.equal(called, 1, 'markupSanitizer called');
-});
-
 test('renders a mobiledoc with atom', (assert) => {
   assert.expect(8);
   let atomName = 'hello-atom';


### PR DESCRIPTION
Update README to mention using a custom markupElementRenderer for 'A'
tag in cases where mobiledoc-dom-renderer cannot determine a url
protocol parser (such as ember-cli-fastboot).