### PR TITLE
Improve protocol detection for href sanitization

### DIFF
--- a/lib/utils/dom.js
+++ b/lib/utils/dom.js
@@ -1,5 +1,3 @@
-/* globals module */
-
 function addHTMLSpaces(text) {
   let nbsp = '\u00A0';
   return text.replace(/  /g, ' ' + nbsp);
@@ -12,6 +10,3 @@ export function createTextNode(dom, text) {
 export function normalizeTagName(tagName) {
   return tagName.toLowerCase();
 }
-
-export const isNode = typeof window === 'undefined' && (typeof module === 'object' && typeof module.require === 'function');
-export const hasDOM = typeof document === 'object';

--- a/lib/utils/sanitization-utils.js
+++ b/lib/utils/sanitization-utils.js
@@ -1,10 +1,6 @@
-/* globals module */
-
 import { includes } from './array-utils';
-import {
-  isNode,
-  hasDOM
-} from './dom';
+
+const PROTOCOL_REGEXP = /^([a-z0-9.+-]+:)/i;
 
 const badProtocols = [
   'javascript:', // jshint ignore:line
@@ -12,25 +8,9 @@ const badProtocols = [
 ];
 
 function getProtocol(url) {
-  if (hasDOM) {
-    /* Presume we are in a browser */
-    let a = document.createElement('a');
-    a.href = url;
-    return a.protocol;
-  } else if (isNode) {
-    /* In node */
-    let nodeURL = module.require('url');
-    let protocol = null;
-    if (typeof url === 'string') {
-      protocol = nodeURL.parse(url).protocol;
-    }
-    return (protocol === null) ? ':' : protocol;
-  } else {
-    throw new Error(
-      'Mobiledoc DOM Renderer is unable to sanitize href tags in this environment.' +
-      'Provide a markupElementRenderer for the \'A\' tag.'
-    );
-  }
+  let matches = url && url.match(PROTOCOL_REGEXP);
+  let protocol = (matches && matches[0]) || ':';
+  return protocol;
 }
 
 export function sanitizeHref(url) {


### PR DESCRIPTION
With the recent addition of href sanitization, there was an environment dependent method to determine a url's protocol.  This simplifies it to a regexp.

- Regexp was picked directly from [node core](https://github.com/nodejs/node/blob/cccc6d8545c0ebd83f934b9734f5605aaeb000f2/lib/url.js#L38)
- Removes the `isNode`/`hasDOM` code which was only used for this feature

I don't believe the sanitization responsibility belongs here in the first place, but since others do, let's do it in a more predictable way and never throw errors.